### PR TITLE
Add a Hlist! type macro to make it easier to write type annotations for HLists.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,12 @@ script:
 after_success:
   - travis-cargo doc-upload
   - if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != "master" ] && [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
-        cargo install cargo-benchcmp --force;
-        cargo bench > benches-variable;
-        git fetch;
-        git checkout master;
-        cargo bench > benches-control;
-        cargo benchcmp benches-control benches-variable;
-        exit 0;
+        cargo install cargo-benchcmp --force &&
+        cargo bench > benches-variable &&
+        git fetch &&
+        git checkout master &&
+        cargo bench > benches-control &&
+        cargo benchcmp benches-control benches-variable
     fi
 
 env:

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ use frunk::hlist::*;
 
 Some basics:
 ```rust
-let h = hlist![1]; 
-// h has a static type of: HCons<{integer}, HNil>
+let h: Hlist!(i32) = hlist![1]; 
+// We use the Hlist! type macro to make it easier to write 
+// a type signature for HLists, which is a series of nested HCons
+// h has a static type of: HCons<i32, HNil>
 
 // HLists have a head and tail
 assert_eq!(hlist![1].head, 1);
@@ -95,6 +97,7 @@ HLists with 2 or more items have a `.into_tuple2()` method that them
 into nested Tuple2s for a nice type-signature and pattern-matching experience
 ```rust
 let h = hlist!["Joe", "Blow", 30, true];
+// Type annotations for HList are optional. Here we let the compiler infer it for us
 // h has a static type of: HCons<&str, HCons<&str, HCons<{integer}, HCons<bool, HNil>>>>
 
 let (f_name, (l_name, (age, is_admin))) = h.into_tuple2();

--- a/benches/validated.rs
+++ b/benches/validated.rs
@@ -4,7 +4,6 @@
 extern crate test;
 
 use frunk::validated::*;
-use frunk::hlist::*;
 use test::Bencher;
 
 fn yah_nah(yah: bool) -> Result<i32, String> {

--- a/src/hlist.rs
+++ b/src/hlist.rs
@@ -19,7 +19,7 @@ use std::ops::Add;
 ///
 /// An HList is a heterogeneous list, one that is statically typed at compile time. In simple terms,
 /// it is just an arbitrarily-nested Tuple2.
-pub trait HList: Sized {
+pub trait HList: Sized{
     /// Returns the length of a given HList
     ///
     /// ```
@@ -149,6 +149,32 @@ macro_rules! hlist {
 
 }
 
+/// Returns a type signature for an HList of the provided types
+///
+/// This is a type macro (introduced in Rust 1.13) that makes it easier
+/// to write nested type signatures.
+///
+/// ```
+/// # #[macro_use] extern crate frunk; use frunk::hlist::*; fn main() {
+///
+/// let h: Hlist!(f32, &str, Option<i32>) = hlist![13.5f32, "hello", Some(41)];
+/// # }
+/// ```
+#[macro_export]
+macro_rules! Hlist {
+    // Nothing
+    () => { $crate::hlist::HNil };
+
+    // Just a single item
+    ($single: ty) => {
+        $crate::hlist::HCons<$single, HNil>
+    };
+
+    ($first: ty, $( $repeated: ty ), +) => {
+        $crate::hlist::HCons<$first, Hlist!($($repeated), *)>
+    };
+}
+
 impl<RHS> Add<RHS> for HNil
     where RHS: HList
 {
@@ -252,7 +278,7 @@ mod tests {
     #[test]
     fn test_macro() {
         assert_eq!(hlist![], HNil);
-        let h = hlist![1, "2", 3];
+        let h: Hlist!(i32, &str, i32) = hlist![1, "2", 3];
         let (h1, tail1) = h.pop();
         assert_eq!(h1, 1);
         assert_eq!(tail1, hlist!["2", 3]);

--- a/src/hlist.rs
+++ b/src/hlist.rs
@@ -19,7 +19,7 @@ use std::ops::Add;
 ///
 /// An HList is a heterogeneous list, one that is statically typed at compile time. In simple terms,
 /// it is just an arbitrarily-nested Tuple2.
-pub trait HList: Sized{
+pub trait HList: Sized {
     /// Returns the length of a given HList
     ///
     /// ```

--- a/src/validated.rs
+++ b/src/validated.rs
@@ -6,7 +6,10 @@
 //! an `HList` of all your results.
 //!
 //! ```
-//! # #[macro_use] extern crate frunk; use frunk::hlist::*; use frunk::validated::*; fn main() {
+//! # #[macro_use] extern crate frunk;
+//! # use frunk::hlist::*;
+//! # use frunk::validated::*;
+//! # fn main() {
 //!
 //! #[derive(PartialEq, Eq, Debug)]
 //! struct Person {
@@ -22,7 +25,7 @@
 //!     Result::Ok(32)
 //! }
 //!
-//! let v = get_name().into_validated() + get_age();
+//! let v: Validated<Hlist!(String, i32), String> = get_name().into_validated() + get_age();
 //! let person = v.into_result()
 //!                .map(|hlist| {
 //!                     let (name, age) = hlist.into_tuple2();


### PR DESCRIPTION
```rust
let h: Hlist!(i32, &str, i32) = hlist![1, "2", 3];
```