### PR TITLE
HList Sculpting, Plucking, Unlabelling and aligned LabelledGeneric conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk provides developers with a number of functional programming tools like HList, Generic, Validated, Monoid, Semigroup and friends."
 license = "MIT"
@@ -9,8 +9,8 @@ keywords = [ "HList", "Generic", "Validated", "Semigroup", "Monoid"]
 
 [dependencies.frunk_core]
 path = "core"
-version = "0.0.6"
+version = "0.0.7"
 
 [dependencies.frunk_derives]
 path = "derives"
-version = "0.0.5"
+version = "0.0.6"

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ let d_user = <DeletedUser as LabelledGeneric>::convert_from(s_user);
 
 // This will, however, work, because we make use of the Sculptor type-class
 // to type-safely reshape the representations to align/match each other.
-let d_user: DeletedUser = aligned_labelled_convert_from(s_user); 
+let d_user: DeletedUser = sculpted_convert_from(s_user); 
 ```
 
 For more information how Generic and Labelled work, check out their respective Rustdocs:

--- a/README.md
+++ b/README.md
@@ -113,7 +113,28 @@ let mapped = h3.map(hlist![
     |s| s,
     |f| f + 1f32]);
 assert_eq!(mapped, hlist![9001, "joe", 42f32]);
+```
 
+You can pluck a type out of an `HList` using `pluck()`, which also gives you back the remainder after plucking that type
+out. This method is checked at compile-time to make sure that the type you ask for *can* be extracted.
+
+```rust
+let h = hlist![1, "hello", true, 42f32];
+let (t, remainder): (bool, _) = h.pluck();
+assert!(t);
+assert_eq!(remainder, hlist![1, "hello", 42f32])
+```
+
+Similarly, you can re-shape, or sculpt, an `Hlist`, there is a `sculpt()` method, which allows you to re-organise and/or
+cull the elements by type. Like `pluck()`, `sculpt()` gives you back your target with the remainder data in a pair. This
+method is also checked at compile time to make sure that it won't fail at runtime (the types in your requested target shape
+must be a subset of the types in the original `HList`.
+
+```rust
+let h = hlist![9000, "joe", 41f32, true];
+let (reshaped, remainder): (Hlist![f32, i32, &str], _) = h.sculpt();
+assert_eq!(reshaped, hlist![41f32, 9000, "joe"]);
+assert_eq!(remainder, hlist![true]);
 ```
 
 ### Generic

--- a/README.md
+++ b/README.md
@@ -239,8 +239,16 @@ struct DeletedUser<'a> {
 }
 
 //  This would fail at compile time :)
-let d_user = <DeletedUser as LabelledGeneric>::convert_from(s_user); 
-```  
+let d_user = <DeletedUser as LabelledGeneric>::convert_from(s_user);
+
+// This will, however, work, because we make use of the Sculptor type-class
+// to type-safely reshape the representations to align/match each other.
+let d_user: DeletedUser = aligned_labelled_convert_from(s_user); 
+```
+
+For more information how Generic and Labelled work, check out their respective Rustdocs:
+  * [Generic](https://beachape.com/frunk/frunk_core/generic/index.html)
+  * [Labelled](https://beachape.com/frunk/frunk_core/labelled/index.html)
 
 ### Validated
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_core"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk core provides developers with HList and Generic"
 license = "MIT"

--- a/core/src/generic.rs
+++ b/core/src/generic.rs
@@ -36,7 +36,6 @@
 /// let d_person: DomainPerson = convert_from(a_person); // done
 /// ```
 pub trait Generic {
-
     /// The generic representation type
     type Repr;
 
@@ -48,7 +47,7 @@ pub trait Generic {
 
     /// From one type to another using a type with a compatible generic representation
     fn convert_from<A>(a: A) -> Self
-        where A: Generic<Repr=Self::Repr>,
+        where A: Generic<Repr = Self::Repr>,
               Self: Sized
     {
         let repr = <A as Generic>::into(a);
@@ -58,22 +57,22 @@ pub trait Generic {
 
 /// Given a generic Representation of an A, returns A
 pub fn from_generic<A, Repr>(gen: Repr) -> A
-    where A: Generic<Repr=Repr>
+    where A: Generic<Repr = Repr>
 {
     <A as Generic>::from(gen)
 }
 
 /// Given an A, returns its generic Representation
 pub fn into_generic<A, Repr>(a: A) -> Repr
-    where A: Generic<Repr=Repr>
+    where A: Generic<Repr = Repr>
 {
     <A as Generic>::into(a)
 }
 
 /// Converts one type into another assuming they have the same generic Representation
 pub fn convert_from<A, B, Repr>(a: A) -> B
-    where A: Generic<Repr=Repr>,
-          B: Generic<Repr=Repr>
+    where A: Generic<Repr = Repr>,
+          B: Generic<Repr = Repr>
 {
     <B as Generic>::convert_from(a)
 }

--- a/core/src/generic.rs
+++ b/core/src/generic.rs
@@ -1,6 +1,6 @@
 //! This module holds the machinery behind Generic.
 //!
-//! It contains the Generic trait and some helper methods for using the Generic type class
+//! It contains the Generic typeclass and some helper methods for using the Generic type class
 //! without having to use universal function call syntax.
 
 /// A trait that converts from a type to a generic representation

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -276,7 +276,6 @@ impl<Head, Tail, FromTail, TailIndex> Selector<FromTail, There<TailIndex>> for H
 /// Similar to Selector, but returns the target and the remainder of the list (w/o target)
 /// in a pair.
 pub trait Plucker<Target, Index> {
-    type Idx;
 
     /// What is left after you pluck the target from the Self
     type Remainder;
@@ -299,7 +298,6 @@ pub trait Plucker<Target, Index> {
 /// Implementation when the pluck target is in head
 impl<T, Tail> Plucker<T, Here> for HCons<T, Tail> {
     type Remainder = Tail;
-    type Idx = Here;
 
     fn pluck(self) -> (T, Self::Remainder) {
         (self.head, self.tail)
@@ -310,7 +308,6 @@ impl<T, Tail> Plucker<T, Here> for HCons<T, Tail> {
 impl<Head, Tail, FromTail, TailIndex> Plucker<FromTail, There<TailIndex>> for HCons<Head, Tail>
     where Tail: Plucker<FromTail, TailIndex>
 {
-    type Idx = There<TailIndex>;
     type Remainder = HCons<Head, <Tail as Plucker<FromTail, TailIndex>>::Remainder>;
 
     fn pluck(self) -> (FromTail, Self::Remainder) {

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -693,10 +693,12 @@ mod tests {
 
     #[test]
     fn test_pluck() {
+
         let h = hlist![1, "hello", true, 42f32];
         let (t, r): (f32, _) = h.pluck();
         assert_eq!(t, 42f32);
         assert_eq!(r, hlist![1, "hello", true])
+
     }
 
     #[test]

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -276,7 +276,6 @@ impl<Head, Tail, FromTail, TailIndex> Selector<FromTail, There<TailIndex>> for H
 /// Similar to Selector, but returns the target and the remainder of the list (w/o target)
 /// in a pair.
 pub trait Plucker<Target, Index> {
-
     /// What is left after you pluck the target from the Self
     type Remainder;
 
@@ -324,7 +323,6 @@ impl<Head, Tail, FromTail, TailIndex> Plucker<FromTail, There<TailIndex>> for HC
 /// An Sculptor trait, that allows us to extract/reshape/scult the current HList into another shape,
 /// provided that the requested shape's types are are contained within the current HList.
 pub trait Sculptor<Target, Indices> {
-
     /// Consumes the current HList and returns an HList with the requested shape.
     ///
     /// ```

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -322,6 +322,9 @@ impl<Head, Tail, FromTail, TailIndex> Plucker<FromTail, There<TailIndex>> for HC
 
 /// An Sculptor trait, that allows us to extract/reshape/scult the current HList into another shape,
 /// provided that the requested shape's types are are contained within the current HList.
+///
+/// The "Indices" type parameter allows the compiler to figure out that the Target and Self
+/// can be morphed into each other
 pub trait Sculptor<Target, Indices> {
     /// Consumes the current HList and returns an HList with the requested shape.
     ///
@@ -338,6 +341,8 @@ pub trait Sculptor<Target, Indices> {
 }
 
 /// Implementation for when the target is an empty HList (HNil)
+///
+/// Index type is HCons<Here, HNil> because we are done
 impl<Source> Sculptor<HNil, HCons<Here, HNil>> for Source {
     fn sculpt(self) -> HNil {
         HNil
@@ -345,6 +350,10 @@ impl<Source> Sculptor<HNil, HCons<Here, HNil>> for Source {
 }
 
 /// Implementation for when we have a non-empty HCons target
+///
+/// Indices is HCons<IndexHead, IndexTail> here because the compiler is being asked to figure out the
+/// Index for Plucking the first item of type THead out of Self and the rest is for the remainder to
+/// figure out.
 impl <THead, TTail, SHead, STail, IndexHead, IndexTail> Sculptor<HCons<THead, TTail>, HCons<IndexHead, IndexTail>>
     for HCons<SHead, STail>
     where

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -283,8 +283,6 @@ pub trait Plucker<Target, Index> {
     ///
     /// ```
     /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
-    ///
-    ///
     /// let h = hlist![1, "hello", true, 42f32];
     /// let (t, r): (bool, _) = h.pluck();
     /// assert!(t);
@@ -332,12 +330,10 @@ pub trait Sculptor<Target, Indices> {
     ///
     /// ```
     /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
-    ///
-    /// let h = hlist![9000, "joe", 41f32];
-    /// // We toss away the remainder because we know there aren't any
-    /// let (reshaped, _): (Hlist![f32, i32, &str], _) = h.sculpt();
-    /// assert_eq!(reshaped, hlist![41f32, 9000, "joe"])
-    ///
+    /// let h = hlist![9000, "joe", 41f32, true];
+    /// let (reshaped, remainder): (Hlist![f32, i32, &str], _) = h.sculpt();
+    /// assert_eq!(reshaped, hlist![41f32, 9000, "joe"]);
+    /// assert_eq!(remainder, hlist![true]);
     /// # }
     /// ```
     fn sculpt(self) -> (Target, Self::Remainder);

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -295,6 +295,7 @@ pub trait Plucker<Target, Index> {
     fn pluck(self) -> (Target, Self::Remainder);
 }
 
+/// Implementation when the pluck target is in head
 impl<T, Tail> Plucker<T, Here> for HCons<T, Tail> {
     type Remainder = Tail;
 
@@ -303,6 +304,7 @@ impl<T, Tail> Plucker<T, Here> for HCons<T, Tail> {
     }
 }
 
+/// Implementation when the pluck target is in the tail
 impl<Head, Tail, FromTail, TailIndex> Plucker<FromTail, There<TailIndex>> for HCons<Head, Tail>
     where Tail: Plucker<FromTail, TailIndex>
 {

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -287,9 +287,9 @@ pub trait Plucker<Target, Index> {
     ///
     ///
     /// let h = hlist![1, "hello", true, 42f32];
-    /// let (t, r): (i32, _) = h.pluck();
-    /// assert_eq!(t, 1);
-    /// assert_eq!(r, hlist!["hello", true, 42f32])
+    /// let (t, r): (bool, _) = h.pluck();
+    /// assert!(t);
+    /// assert_eq!(r, hlist![1, "hello", 42f32])
     /// # }
     /// ```
     fn pluck(self) -> (Target, Self::Remainder);
@@ -594,6 +594,14 @@ mod tests {
         assert_eq!(retrieved.length(), 1);
         let new_list = h_cons(2, retrieved);
         assert_eq!(new_list.length(), 2);
+    }
+
+    #[test]
+    fn test_pluck() {
+        let h = hlist![1, "hello", true, 42f32];
+        let (t, r): (f32, _) = h.pluck();
+        assert_eq!(t, 42f32);
+        assert_eq!(r, hlist![1, "hello", true])
     }
 
     #[test]

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -725,7 +725,7 @@ mod tests {
     #[test]
     fn test_sculpt() {
         let h = hlist![9000, "joe", 41f32];
-        let extracted: Hlist!(f32, i32) = h.sculpt();
-        assert_eq!(extracted, hlist![41f32, 9000])
+        let reshaped: Hlist!(f32, i32) = h.sculpt();
+        assert_eq!(reshaped, hlist![41f32, 9000])
     }
 }

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -352,8 +352,8 @@ impl<Source> Sculptor<HNil, HCons<Here, HNil>> for Source {
 /// Implementation for when we have a non-empty HCons target
 ///
 /// Indices is HCons<IndexHead, IndexTail> here because the compiler is being asked to figure out the
-/// Index for Plucking the first item of type THead out of Self and the rest is for the remainder to
-/// figure out.
+/// Index for Plucking the first item of type THead out of Self and the rest (IndexTail) is for the
+/// Plucker's remainder induce.
 impl <THead, TTail, SHead, STail, IndexHead, IndexTail> Sculptor<HCons<THead, TTail>, HCons<IndexHead, IndexTail>>
     for HCons<SHead, STail>
     where

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -1,4 +1,4 @@
-//! Module that holds HList data structures and implementations
+//! Module that holds HList data structures, implementations, and typeclasses.
 //!
 //! Typically, you would want to use the `hlist!` macro to make it easier
 //! for you to use HList.
@@ -10,6 +10,42 @@
 //! let (a, b) = h.into_tuple2();
 //! assert_eq!(a, 1);
 //! assert_eq!(b, "hi");
+//!
+//! // Reverse
+//! let h1 = hlist![true, "hi"];
+//! assert_eq!(h1.into_reverse(), hlist!["hi", true]);
+//!
+//! // foldr (foldl also available)
+//! let h2 = hlist![1, false, 42f32];
+//! let folded = h2.foldr(
+//!             hlist![
+//!                 |i, acc| i + acc,
+//!                 |_, acc| if acc > 42f32 { 9000 } else { 0 },
+//!                 |f, acc| f + acc
+//!             ],
+//!             1f32
+//!     );
+//! assert_eq!(folded, 9001);
+//!
+//! // Mapping over an HList
+//! let h3 = hlist![9000, "joe", 41f32];
+//! let mapped = h3.map(hlist![
+//!                         |n| n + 1,
+//!                         |s| s,
+//!                         |f| f + 1f32]);
+//! assert_eq!(mapped, hlist![9001, "joe", 42f32]);
+//!
+//! // Plucking a value out by type
+//! let h4 = hlist![1, "hello", true, 42f32];
+//! let (t, remainder): (bool, _) = h4.pluck();
+//! assert!(t);
+//! assert_eq!(remainder, hlist![1, "hello", 42f32]);
+//!
+//! // Resculpting an HList
+//! let h5 = hlist![9000, "joe", 41f32, true];
+//! let (reshaped, remainder2): (Hlist![f32, i32, &str], _) = h5.sculpt();
+//! assert_eq!(reshaped, hlist![41f32, 9000, "joe"]);
+//! assert_eq!(remainder2, hlist![true]);
 //! # }
 //! ```
 

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -721,8 +721,10 @@ mod tests {
 
     #[test]
     fn test_sculpt() {
+
         let h = hlist![9000, "joe", 41f32];
         let reshaped: Hlist!(f32, i32) = h.sculpt();
         assert_eq!(reshaped, hlist![41f32, 9000])
+
     }
 }

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -74,6 +74,7 @@ pub trait LabelledGeneric {
     fn sculpted_convert_from<A, Indices>(a: A) -> Self
         where A: LabelledGeneric,
               Self: Sized,
+              // The labelled representation of A must be sculpt-able into the labelled representation of Self
               <A as LabelledGeneric>::Repr: Sculptor<<Self as LabelledGeneric>::Repr, Indices> {
         let a_gen = <A as LabelledGeneric>::into(a);
         // We toss away the remainder.
@@ -112,6 +113,7 @@ pub fn labelled_convert_from<A, B, Repr>(a: A) -> B
 pub fn sculpted_convert_from<A, B, Indices>(a: A) -> B
     where A: LabelledGeneric,
           B: LabelledGeneric,
+          // The labelled representation of A must be sculpt-able into the labelled representation of B
           <A as LabelledGeneric>::Repr: Sculptor<<B as LabelledGeneric>::Repr, Indices> {
     <B as LabelledGeneric>::sculpted_convert_from(a)
 }
@@ -176,7 +178,6 @@ pub trait IntoUnlabelled {
     /// let unlabelled = labelled_hlist.into_unlabelled();
     ///
     /// assert_eq!(unlabelled, hlist!["joe", 3])
-    ///
     /// # }
     /// ```
     fn into_unlabelled(self) -> Self::Output;

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -68,12 +68,16 @@ pub trait LabelledGeneric {
 
     /// Converts from another type A into Self assuming that A and Self have labelled generic representations
     /// that can be sculpted into each other.
+    ///
+    /// Note that this method tosses away the "remainder" of the sculpted representation. In other
+    /// words, anything that is not needed from A gets tossed out.
     fn sculpted_convert_from<A, Indices>(a: A) -> Self
         where A: LabelledGeneric,
               Self: Sized,
               <A as LabelledGeneric>::Repr: Sculptor<<Self as LabelledGeneric>::Repr, Indices> {
         let a_gen = <A as LabelledGeneric>::into(a);
-        let self_gen: <Self as LabelledGeneric>::Repr = a_gen.sculpt();
+        // We toss away the remainder.
+        let (self_gen, _): (<Self as LabelledGeneric>::Repr, _) = a_gen.sculpt();
         <Self as LabelledGeneric>::from(self_gen)
     }
 }
@@ -211,6 +215,7 @@ mod tests {
         assert_eq!(f1, f2)
     }
 
+    #[test]
     fn test_unlabelling() {
         let labelled_hlist = hlist![label::<(n, a, m, e), &str>("joe"), label::<(a, g, e), i32>(3)];
         let unlabelled = labelled_hlist.into_unlabelled();

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -14,7 +14,7 @@
 use std::marker::PhantomData;
 use hlist::*;
 
-/// A trait that converts from a type to a generic representation
+/// A trait that converts from a type to a labelled generic representation
 ///
 /// For the most part, you should be using the derivation that is available through
 /// frunk_derive to generate instances of this typeclass for your types.
@@ -48,16 +48,16 @@ use hlist::*;
 /// let s_user = <SavedUser as LabelledGeneric>::convert_from(n_user); // done
 /// ```
 pub trait LabelledGeneric {
-    /// The generic representation type
+    /// The labelled generic representation type
     type Repr;
 
     /// Go from something to Repr
     fn into(self) -> Self::Repr;
 
-    /// Go from Repr to something
+    /// Go from labelled Repr to something
     fn from(r: Self::Repr) -> Self;
 
-    /// From one type to another using a type with a compatible generic representation
+    /// From one type to another using a type with a compatible labelled generic representation
     fn convert_from<A>(a: A) -> Self
         where A: LabelledGeneric<Repr = Self::Repr>,
               Self: Sized
@@ -110,8 +110,8 @@ pub fn labelled_convert_from<A, B, Repr>(a: A) -> B
 /// The "Indices" type parameter allows the compiler to figure out that the two representations
 /// can indeed be morphed into each other.
 pub fn sculpted_convert_from<A, B, Indices>(a: A) -> B
-    where B: LabelledGeneric,
-          A: LabelledGeneric,
+    where A: LabelledGeneric,
+          B: LabelledGeneric,
           <A as LabelledGeneric>::Repr: Sculptor<<B as LabelledGeneric>::Repr, Indices> {
     <B as LabelledGeneric>::sculpted_convert_from(a)
 }

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -47,7 +47,6 @@ use std::marker::PhantomData;
 /// let s_user = <SavedUser as LabelledGeneric>::convert_from(n_user); // done
 /// ```
 pub trait LabelledGeneric {
-
     /// The generic representation type
     type Repr;
 
@@ -59,7 +58,7 @@ pub trait LabelledGeneric {
 
     /// From one type to another using a type with a compatible generic representation
     fn convert_from<A>(a: A) -> Self
-        where A: LabelledGeneric<Repr=Self::Repr>,
+        where A: LabelledGeneric<Repr = Self::Repr>,
               Self: Sized
     {
         let repr = <A as LabelledGeneric>::into(a);
@@ -69,22 +68,22 @@ pub trait LabelledGeneric {
 
 /// Given a labelled generic Representation of an A, returns A
 pub fn from_labelled_generic<A, Repr>(gen: Repr) -> A
-    where A: LabelledGeneric<Repr=Repr>
+    where A: LabelledGeneric<Repr = Repr>
 {
     <A as LabelledGeneric>::from(gen)
 }
 
 /// Given an A, returns its labelled generic Representation
 pub fn into_labelled_generic<A, Repr>(a: A) -> Repr
-    where A: LabelledGeneric<Repr=Repr>
+    where A: LabelledGeneric<Repr = Repr>
 {
     <A as LabelledGeneric>::into(a)
 }
 
 /// Converts one type into another assuming they have the same labelled generic Representation
 pub fn labelled_convert_from<A, B, Repr>(a: A) -> B
-    where A: LabelledGeneric<Repr=Repr>,
-          B: LabelledGeneric<Repr=Repr>
+    where A: LabelledGeneric<Repr = Repr>,
+          B: LabelledGeneric<Repr = Repr>
 {
     <B as LabelledGeneric>::convert_from(a)
 }

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -218,8 +218,12 @@ mod tests {
 
     #[test]
     fn test_unlabelling() {
-        let labelled_hlist = hlist![label::<(n, a, m, e), &str>("joe"), label::<(a, g, e), i32>(3)];
+
+        let labelled_hlist = hlist![
+            label::<(n, a, m, e), &str>("joe"),
+            label::<(a, g, e), i32>(3)];
         let unlabelled = labelled_hlist.into_unlabelled();
         assert_eq!(unlabelled, hlist!["joe", 3])
+
     }
 }

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -91,6 +91,9 @@ pub fn labelled_convert_from<A, B, Repr>(a: A) -> B
 
 /// Converts from one type into another assuming that their labelled generic representations
 /// can be sculpted into each other.
+///
+/// The "Indices" type parameter allows the compiler to figure out that the two representations
+/// can indeed be morphed into each other.
 pub fn aligned_labelled_convert_from<A, B, Indices>(a: A) -> B
     where B: LabelledGeneric,
           A: LabelledGeneric,

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -65,6 +65,17 @@ pub trait LabelledGeneric {
         let repr = <A as LabelledGeneric>::into(a);
         <Self as LabelledGeneric>::from(repr)
     }
+
+    /// Converts from another type A into Self assuming that A and Self have labelled generic representations
+    /// that can be sculpted into each other.
+    fn sculpted_convert_from<A, Indices>(a: A) -> Self
+        where A: LabelledGeneric,
+              Self: Sized,
+              <A as LabelledGeneric>::Repr: Sculptor<<Self as LabelledGeneric>::Repr, Indices> {
+        let a_gen = <A as LabelledGeneric>::into(a);
+        let self_gen: <Self as LabelledGeneric>::Repr = a_gen.sculpt();
+        <Self as LabelledGeneric>::from(self_gen)
+    }
 }
 
 /// Given a labelled generic Representation of an A, returns A
@@ -94,13 +105,11 @@ pub fn labelled_convert_from<A, B, Repr>(a: A) -> B
 ///
 /// The "Indices" type parameter allows the compiler to figure out that the two representations
 /// can indeed be morphed into each other.
-pub fn aligned_labelled_convert_from<A, B, Indices>(a: A) -> B
+pub fn sculpted_convert_from<A, B, Indices>(a: A) -> B
     where B: LabelledGeneric,
           A: LabelledGeneric,
           <A as LabelledGeneric>::Repr: Sculptor<<B as LabelledGeneric>::Repr, Indices> {
-    let a_gen = <A as LabelledGeneric>::into(a);
-    let b_gen: <B as LabelledGeneric>::Repr = a_gen.sculpt();
-    <B as LabelledGeneric>::from(b_gen)
+    <B as LabelledGeneric>::sculpted_convert_from(a)
 }
 
 // Create a bunch of enums that can be used to represent characters on the type level

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -184,4 +184,13 @@ mod tests {
         let f2 = label::<(a, g, e), i32>(3);
         assert_eq!(f1, f2)
     }
+
+    fn test_unlabelling() {
+      let labelled_hlist = hlist![
+          label::<(n, a, m, e), &str>("joe"),
+          label::<(a, g, e), i32>(3)
+      ];
+      let unlabelled = labelled_hlist.into_unlabelled();
+      assert_eq!(unlabelled, hlist!["joe", 3])
+    }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,7 +7,6 @@
 //! ```
 //! # #[macro_use] extern crate frunk_core;
 //! # use frunk_core::hlist::*;
-//! # use frunk_core::hlist::*;
 //! # fn main() {
 //!
 //! let h = hlist![1, false, 42f32];
@@ -15,7 +14,43 @@
 //!     |_, acc| if acc > 42f32 { 9000 } else { 0 },
 //!     |f, acc| f + acc],
 //!     1f32);
-//! assert_eq!(folded, 9001)
+//! assert_eq!(folded, 9001);
+//!
+//! // Reverse
+//! let h1 = hlist![true, "hi"];
+//! assert_eq!(h1.into_reverse(), hlist!["hi", true]);
+//!
+//! // foldr (foldl also available)
+//! let h2 = hlist![1, false, 42f32];
+//! let folded = h2.foldr(
+//!             hlist![
+//!                 |i, acc| i + acc,
+//!                 |_, acc| if acc > 42f32 { 9000 } else { 0 },
+//!                 |f, acc| f + acc
+//!             ],
+//!             1f32
+//!     );
+//! assert_eq!(folded, 9001);
+//!
+//! // Mapping over an HList
+//! let h3 = hlist![9000, "joe", 41f32];
+//! let mapped = h3.map(hlist![
+//!                         |n| n + 1,
+//!                         |s| s,
+//!                         |f| f + 1f32]);
+//! assert_eq!(mapped, hlist![9001, "joe", 42f32]);
+//!
+//! // Plucking a value out by type
+//! let h4 = hlist![1, "hello", true, 42f32];
+//! let (t, remainder): (bool, _) = h4.pluck();
+//! assert!(t);
+//! assert_eq!(remainder, hlist![1, "hello", 42f32]);
+//!
+//! // Resculpting an HList
+//! let h5 = hlist![9000, "joe", 41f32, true];
+//! let (reshaped, remainder2): (Hlist![f32, i32, &str], _) = h5.sculpt();
+//! assert_eq!(reshaped, hlist![41f32, 9000, "joe"]);
+//! assert_eq!(remainder2, hlist![true]);
 //! # }
 //! ```
 //!

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_derives"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "frunk_derives contains the custom derivations for certain traits in Frunk."
 license = "MIT"
@@ -16,4 +16,4 @@ quote = "0.3.12"
 
 [dependencies.frunk_core]
 path = "../core"
-version = "0.0.6"
+version = "0.0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,11 @@
 //!     age: usize,
 //! }
 //! // let d_user = <DeletedUser as LabelledGeneric>::convert_from(s_user); <-- this would fail at compile time :)
+//!
+//! // This will, however, work, because we make use of the Sculptor type-class
+//! // to type-safely reshape the representations to align/match each other.
+//! let d_user: DeletedUser = sculpted_convert_from(s_user);
+//! assert_eq!(d_user.first_name, "Joe");
 //! # }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ pub mod monoid;
 pub mod validated;
 
 pub use frunk_core::hlist::*;
+pub use frunk_core::labelled::*;
 // this needs to be globally imported in order for custom derives to work w/o fuss
 pub use frunk_core::generic::*;
 

--- a/tests/derivation_tests.rs
+++ b/tests/derivation_tests.rs
@@ -220,7 +220,7 @@ fn test_aligned_labelled_convert_from() {
         age: 30
     };
     // even less boilerplate than before
-    let j_u: JumbledUser = aligned_labelled_convert_from(n_u); // Done
+    let j_u: JumbledUser = sculpted_convert_from(n_u); // Done
 
     assert_eq!(j_u.first_name, "Moe");
     assert_eq!(j_u.last_name, "Ali");

--- a/tests/derivation_tests.rs
+++ b/tests/derivation_tests.rs
@@ -178,22 +178,22 @@ fn test_mixed_conversions_round_trip() {
 }
 
 
+#[derive(LabelledGeneric)]
+struct NormalUser<'a> {
+    first_name: &'a str,
+    last_name: &'a str,
+    age: usize
+}
+// Fields are jumbled :(
+#[derive(LabelledGeneric)]
+struct JumbledUser<'a> {
+    last_name: &'a str,
+    age: usize,
+    first_name: &'a str,
+}
+
 #[test]
 fn test_reshaped_labelled_generic_conversion() {
-
-    #[derive(LabelledGeneric)]
-    struct NormalUser<'a> {
-        first_name: &'a str,
-        last_name: &'a str,
-        age: usize
-    }
-    // Fields are jumbled :(
-    #[derive(LabelledGeneric)]
-    struct JumbledUser<'a> {
-        last_name: &'a str,
-        age: usize,
-        first_name: &'a str,
-    }
 
     let n_u = NormalUser {
         first_name: "Moe",
@@ -205,6 +205,22 @@ fn test_reshaped_labelled_generic_conversion() {
     // Reshape the labelled generic to fit the JumbledUser's generic Repr
     let jumbled_gen: <JumbledUser as LabelledGeneric>::Repr = n_gen.sculpt();
     let j_u: JumbledUser = from_labelled_generic(jumbled_gen); // Done
+
+    assert_eq!(j_u.first_name, "Moe");
+    assert_eq!(j_u.last_name, "Ali");
+    assert_eq!(j_u.age, 30)
+}
+
+#[test]
+fn test_aligned_labelled_convert_from() {
+
+    let n_u = NormalUser {
+        first_name: "Moe",
+        last_name: "Ali",
+        age: 30
+    };
+    // even less boilerplate than before
+    let j_u: JumbledUser = aligned_labelled_convert_from(n_u); // Done
 
     assert_eq!(j_u.first_name, "Moe");
     assert_eq!(j_u.last_name, "Ali");

--- a/tests/derivation_tests.rs
+++ b/tests/derivation_tests.rs
@@ -203,7 +203,7 @@ fn test_reshaped_labelled_generic_conversion() {
     // Convert to labelled-generic representation
     let n_gen = into_labelled_generic(n_u);
     // Reshape the labelled generic to fit the JumbledUser's generic Repr
-    let jumbled_gen: <JumbledUser as LabelledGeneric>::Repr = n_gen.sculpt();
+    let (jumbled_gen, _): (<JumbledUser as LabelledGeneric>::Repr, _) = n_gen.sculpt();
     let j_u: JumbledUser = from_labelled_generic(jumbled_gen); // Done
 
     assert_eq!(j_u.first_name, "Moe");

--- a/tests/derivation_tests.rs
+++ b/tests/derivation_tests.rs
@@ -178,6 +178,41 @@ fn test_mixed_conversions_round_trip() {
 }
 
 
+#[test]
+fn test_reshaped_labelled_generic_conversion() {
+
+    #[derive(LabelledGeneric)]
+    struct NormalUser<'a> {
+        first_name: &'a str,
+        last_name: &'a str,
+        age: usize
+    }
+
+    // Fields are jumbled :(
+    #[derive(LabelledGeneric)]
+    struct JumbledUser<'a> {
+        last_name: &'a str,
+        age: usize,
+        first_name: &'a str,
+    }
+
+    let n_u = NormalUser {
+        first_name: "Moe",
+        last_name: "Ali",
+        age: 30
+    };
+
+    let n_gen = into_labelled_generic(n_u);
+    let jumbled_gen: <JumbledUser as LabelledGeneric>::Repr = n_gen.sculpt();
+
+    let j_u: JumbledUser = from_labelled_generic(jumbled_gen);
+
+    assert_eq!(j_u.first_name, "Moe");
+    assert_eq!(j_u.last_name, "Ali");
+    assert_eq!(j_u.age, 30)
+}
+
+
 // Working with Validated
 
 #[derive(PartialEq, Eq, Debug)]

--- a/tests/derivation_tests.rs
+++ b/tests/derivation_tests.rs
@@ -187,7 +187,6 @@ fn test_reshaped_labelled_generic_conversion() {
         last_name: &'a str,
         age: usize
     }
-
     // Fields are jumbled :(
     #[derive(LabelledGeneric)]
     struct JumbledUser<'a> {
@@ -201,11 +200,11 @@ fn test_reshaped_labelled_generic_conversion() {
         last_name: "Ali",
         age: 30
     };
-
+    // Convert to labelled-generic representation
     let n_gen = into_labelled_generic(n_u);
+    // Reshape the labelled generic to fit the JumbledUser's generic Repr
     let jumbled_gen: <JumbledUser as LabelledGeneric>::Repr = n_gen.sculpt();
-
-    let j_u: JumbledUser = from_labelled_generic(jumbled_gen);
+    let j_u: JumbledUser = from_labelled_generic(jumbled_gen); // Done
 
     assert_eq!(j_u.first_name, "Moe");
     assert_eq!(j_u.last_name, "Ali");


### PR DESCRIPTION
- [x] Add the ability to pluck a value from an HList and get back the remainder
- [x] Add the ability to reshape/sculpt an HList into a given type-shape provided the types are a subset of the types in the current HList
- [x] Add the ability to convert a Labelled HList into an unlabelled one.
- [x] Add the ability to convert between instances that have compatible LabelledGeneric representations (can be re-sculpted to match the each other).