### PR TITLE
Make LabelledGeneric derivation encode Label names w/ unicode if required

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk"
-version = "0.1.15"
+version = "0.1.16"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk provides developers with a number of functional programming tools like HList, Generic, Validated, Monoid, Semigroup and friends."
 license = "MIT"
@@ -13,4 +13,4 @@ version = "0.0.7"
 
 [dependencies.frunk_derives]
 path = "derives"
-version = "0.0.6"
+version = "0.0.7"

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -130,7 +130,7 @@ macro_rules! create_enums_for {
 }
 
 // Add more as needed.
-create_enums_for! { a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D E F G H I J K L M N O P Q R S T U V W X Y Z __ _1 _2 _3 _4 _5 _6 _7 _8 _9 _0 }
+create_enums_for! { a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D E F G H I J K L M N O P Q R S T U V W X Y Z __ _1 _2 _3 _4 _5 _6 _7 _8 _9 _0 _uc uc_ }
 
 #[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
 pub struct Labelled<Name, Type> {

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_derives"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "frunk_derives contains the custom derivations for certain traits in Frunk."
 license = "MIT"


### PR DESCRIPTION
Currently only-ascii identifiers are supported in Rust, but that might not always be the case.

This change allows us to encode non-standard (not a-z, A-Z, _, or 0-9) characters as unicode hex codes equivalents bookended by `_uc` and `uc_` enums.