### PR TITLE
Feature/runtime labelled names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk"
-version = "0.1.17"
+version = "0.1.18"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk provides developers with a number of functional programming tools like HList, Generic, Validated, Monoid, Semigroup and friends."
 license = "MIT"
@@ -9,8 +9,8 @@ keywords = [ "HList", "Generic", "Validated", "Semigroup", "Monoid"]
 
 [dependencies.frunk_core]
 path = "core"
-version = "0.0.7"
+version = "0.0.8"
 
 [dependencies.frunk_derives]
 path = "derives"
-version = "0.0.8"
+version = "0.0.9"

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ let d_user = <DeletedUser as LabelledGeneric>::convert_from(s_user);
 let d_user: DeletedUser = sculpted_convert_from(s_user); 
 ```
 
-For more information how Generic and Labelled work, check out their respective Rustdocs:
+For more information how Generic and Field work, check out their respective Rustdocs:
   * [Generic](https://beachape.com/frunk/frunk_core/generic/index.html)
   * [Labelled](https://beachape.com/frunk/frunk_core/labelled/index.html)
 

--- a/benches/generic.rs
+++ b/benches/generic.rs
@@ -1,0 +1,35 @@
+#![feature(test)]
+
+#[macro_use]
+extern crate frunk;
+extern crate frunk_core;
+extern crate test;
+
+use frunk::*;
+use test::Bencher;
+
+#[derive(Generic)]
+struct NewUser<'a> {
+    first_name: &'a str,
+    last_name: &'a str,
+    age: usize
+}
+
+#[derive(Generic)]
+struct SavedUser<'a> {
+    first_name: &'a str,
+    last_name: &'a str,
+    age: usize
+}
+
+#[bench]
+fn generic_conversion(b: &mut Bencher) {
+    b.iter(|| {
+        let n_u = NewUser {
+            first_name: "Joe",
+            last_name: "Schmoe",
+            age: 30
+        };
+        <SavedUser as Generic>::convert_from(n_u)
+    })
+}

--- a/benches/labelled.rs
+++ b/benches/labelled.rs
@@ -37,7 +37,7 @@ fn labelled_conversion(b: &mut Bencher) {
 
 #[bench]
 fn name(b: &mut Bencher) {
-    let field = label!((f,i,r,s,t,__,n,a,m,e), 30);
+    let field = field!((f,i,r,s,t,__,n,a,m,e), 30);
     b.iter(|| {
         field.name
     })

--- a/benches/labelled.rs
+++ b/benches/labelled.rs
@@ -1,0 +1,44 @@
+#![feature(test)]
+
+#[macro_use]
+extern crate frunk;
+#[macro_use]
+extern crate frunk_core;
+extern crate test;
+
+use frunk::*;
+use test::Bencher;
+
+#[derive(LabelledGeneric)]
+struct NewUser<'a> {
+    first_name: &'a str,
+    last_name: &'a str,
+    age: usize
+}
+
+#[derive(LabelledGeneric)]
+struct SavedUser<'a> {
+    first_name: &'a str,
+    last_name: &'a str,
+    age: usize
+}
+
+#[bench]
+fn labelled_conversion(b: &mut Bencher) {
+    b.iter(|| {
+        let n_u = NewUser {
+            first_name: "Joe",
+            last_name: "Schmoe",
+            age: 30
+        };
+        <SavedUser as LabelledGeneric>::sculpted_convert_from(n_u)
+    })
+}
+
+#[bench]
+fn name(b: &mut Bencher) {
+    let field = label::<Hlist![f,i,r,s,t,__,n,a,m,e], _>(30);
+    b.iter(|| {
+        field.name()
+    })
+}

--- a/benches/labelled.rs
+++ b/benches/labelled.rs
@@ -37,8 +37,8 @@ fn labelled_conversion(b: &mut Bencher) {
 
 #[bench]
 fn name(b: &mut Bencher) {
-    let field = label::<Hlist![f,i,r,s,t,__,n,a,m,e], _>(30);
+    let field = label!((f,i,r,s,t,__,n,a,m,e), 30);
     b.iter(|| {
-        field.name()
+        field.name
     })
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_core"
-version = "0.0.7"
+version = "0.0.8"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk core provides developers with HList and Generic"
 license = "MIT"

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -208,10 +208,10 @@ pub trait Named {
     fn name(&self) -> String;
 }
 
-impl <Name: RuntimeString, Value> Named for Labelled<Name, Value> {
+impl <Name: HasRuntimeString, Value> Named for Labelled<Name, Value> {
 
     fn name(&self) -> String {
-        let raw = <Name as RuntimeString>::get_string();
+        let raw = <Name as HasRuntimeString>::get_string();
         decode_unicode(raw)
     }
 }
@@ -225,7 +225,7 @@ pub struct Labelled<Name, Type> {
 impl <Name, Type> fmt::Debug for Labelled<Name, Type>
     where
         Type: fmt::Debug,
-        Name: RuntimeString {
+        Name: HasRuntimeString {
 
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let v_debug = format!("{:?}", self.value);
@@ -313,19 +313,19 @@ mod internal {
     /// Trait for getting the runtime String representation for a type
     ///
     /// DO NOT implement this trait yourself unless you know what you are doing.
-    pub trait RuntimeString {
+    pub trait HasRuntimeString {
         fn get_string() -> String;
     }
 
-    impl RuntimeString for HNil {
+    impl HasRuntimeString for HNil {
         fn get_string() -> String { "".to_string() }
     }
 
-    impl <Char, Tail> RuntimeString for HCons<Char, Tail>
+    impl <Char, Tail> HasRuntimeString for HCons<Char, Tail>
         where Char: AsStaticStr,
-              Tail: RuntimeString {
+              Tail: HasRuntimeString {
         fn get_string() -> String {
-            format!("{}{}", <Char as AsStaticStr>::get_char(), <Tail as RuntimeString>::get_string() )
+            format!("{}{}", <Char as AsStaticStr>::get_char(), <Tail as HasRuntimeString>::get_string() )
         }
     }
 

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -153,8 +153,7 @@ impl <Name, Type> fmt::Debug for Labelled<Name, Type>
 ///
 /// If you don't want to provide a custom name and want to rely on the type you provide
 /// to build a name, then please use the label! macro.
-pub fn label_with_name<Label, Value>(value: Value, name: &'static str) -> Labelled<Label, Value>
-    where Label: HList {
+pub fn label_with_name<Label, Value>(value: Value, name: &'static str) -> Labelled<Label, Value> {
     Labelled {
         name_type_holder: PhantomData,
         name: name,
@@ -248,7 +247,7 @@ macro_rules! type_string {
 macro_rules! label {
     // We are provided a stable name
     (($($repeated: ty),*), $value: expr, $name: expr) => {
-        $crate::labelled::label_with_name::<Hlist!($($repeated),*),_>($value, $name)
+        $crate::labelled::label_with_name::<($($repeated),*),_>($value, $name)
     };
     // No name provided, trailing comma types case
     (($($repeated: ty,)*), $value: expr, $name: expr) => {
@@ -299,7 +298,7 @@ mod tests {
             label!((n, a, m, e), "Joe"),
             label!((a, g, e), 30)
         ];
-        let (name, _): (Labelled<Hlist![n, a, m, e], _>, _) = record.pluck();
+        let (name, _): (Labelled<(n, a, m, e), _>, _) = record.pluck();
         assert_eq!(name.value, "Joe")
     }
 

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -14,7 +14,6 @@
 use std::marker::PhantomData;
 use hlist::*;
 use std::fmt;
-use self::internal::*;
 
 /// A trait that converts from a type to a labelled generic representation
 ///
@@ -120,14 +119,6 @@ pub fn sculpted_convert_from<A, B, Indices>(a: A) -> B
     <B as LabelledGeneric>::sculpted_convert_from(a)
 }
 
-/// Trait for getting the static string representation of a type
-///
-/// Used mostly for building the runtime representation of the name of a labelled type, one
-/// char at a time.
-pub trait AsStaticStr {
-    fn get_char() -> &'static str;
-}
-
 // Create a bunch of enums that can be used to represent characters on the type level
 macro_rules! create_enums_for {
     ($($i: ident)*) => {
@@ -135,135 +126,36 @@ macro_rules! create_enums_for {
             #[allow(non_snake_case, non_camel_case_types)]
             #[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
             pub enum $i {}
-
-            impl AsStaticStr for $i {
-                fn get_char() -> &'static str { stringify!($i) }
-            }
-        )*
-    }
-}
-
-// Same as above, but for identifiers that need to be prefixed with an underscore
-macro_rules! create_enums_for_underlined {
-    ($($i: ident)*) => {
-        $(
-            #[allow(non_snake_case, non_camel_case_types)]
-            #[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
-            pub enum $i {}
-
-            impl AsStaticStr for $i {
-                fn get_char() -> &'static str { &stringify!($i)[1..2] }
-            }
         )*
     }
 }
 
 // Add more as needed.
-create_enums_for! { a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D E F G H I J K L M N O P Q R S T U V W X Y Z }
-create_enums_for_underlined! { __ _1 _2 _3 _4 _5 _6 _7 _8 _9 _0  }
-
-// Define these escape ones manually
-#[allow(non_snake_case, non_camel_case_types)]
-#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
-pub enum _uc {}
-
-/// Implementation for bookending unicode characters
-impl AsStaticStr for _uc {
-
-    /// The escape character for the beginning of a unicode sequence
-    ///
-    /// If this is changed, make sure to update the characters used in
-    /// decoding (see self::internal)
-    fn get_char() -> &'static str { "{" }
-}
-// Define these escape ones manually
-#[allow(non_snake_case, non_camel_case_types)]
-#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
-pub enum uc_ {}
-
-/// Implementation for bookending unicode characters
-impl AsStaticStr for uc_ {
-
-    /// The escape character for the end of a unicode sequence
-    ///
-    /// If this is changed, make sure to update the characters used in
-    /// decoding (see self::internal)
-    fn get_char() -> &'static str { "}" }
-}
-
-/// Trait for getting the String representation of a Labelled's Name type
-pub trait Named {
-
-    /// Returns the label
-    ///
-    /// ```
-    /// # #[macro_use] extern crate frunk_core;
-    /// # use frunk_core::labelled::*;
-    /// # use frunk_core::hlist::*;
-    /// # fn main() {
-    /// let labelled = label::<Hlist![n, a, m, e], &str>("joe");
-    /// assert_eq!(labelled.name(), "name".to_string())
-    /// # }
-    /// ```
-    fn name(&self) -> String;
-}
-
-impl <Name: HasRuntimeString, Value> Named for Labelled<Name, Value> {
-
-    fn name(&self) -> String {
-        let raw = <Name as HasRuntimeString>::get_string();
-        decode_unicode(raw)
-    }
-}
+create_enums_for! { a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D E F G H I J K L M N O P Q R S T U V W X Y Z __ _1 _2 _3 _4 _5 _6 _7 _8 _9 _0 }
 
 #[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
 pub struct Labelled<Name, Type> {
-    name: PhantomData<Name>,
-    pub value: Type,
-}
-
-impl <Name, Type> fmt::Debug for Labelled<Name, Type>
-    where
-        Type: fmt::Debug,
-        Name: HasRuntimeString {
-
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let v_debug = format!("{:?}", self.value);
-        write!(f, "Labelled{{ name: {}, value: {} }}", self.name(), v_debug)
-    }
-}
-
-/// Helper function for building a new Labelled value.
-///
-/// Useful so that users don't need to deal with PhantomData directly.
-///
-/// ```
-/// # #[macro_use] extern crate frunk_core;
-/// # use frunk_core::labelled::*;
-/// # use frunk_core::hlist::*;
-/// # fn main() {
-/// let f1 = label::<Hlist![a, g, e], i32>(3);
-/// let f2 = label::<Hlist![a, g, e], i32>(3);
-/// assert_eq!(f1, f2)
-/// # }
-/// ```
-pub fn label<Label, Value>(value: Value) -> Labelled<Label, Value> {
-    Labelled {
-        name: PhantomData,
-        value: value,
-    }
-}
-
-
-#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
-pub struct LabelledNew<Name, Type> {
     name_type_holder: PhantomData<Name>,
     pub name: &'static str,
     pub value: Type,
 }
 
-pub fn build_label_new<Label, Value>(value: Value, name: &'static str) -> LabelledNew<Label, Value> where Label: HList {
-    LabelledNew {
+impl <Name, Type> fmt::Debug for Labelled<Name, Type>
+    where Type: fmt::Debug {
+
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let v_debug = format!("{:?}", self.value);
+        write!(f, "Labelled{{ name: {}, value: {} }}", self.name, v_debug)
+    }
+}
+
+/// Returns a new label for a given value and custom name.
+///
+/// If you don't want to provide a custom name and want to rely on the type you provide
+/// to build a name, then please use the label! macro.
+pub fn label_with_name<Label, Value>(value: Value, name: &'static str) -> Labelled<Label, Value>
+    where Label: HList {
+    Labelled {
         name_type_holder: PhantomData,
         name: name,
         value: value,
@@ -285,8 +177,8 @@ pub trait IntoUnlabelled {
     /// # fn main() {
     ///
     /// let labelled_hlist = hlist![
-    ///     label::<Hlist![n, a, m, e], _>("joe"),
-    ///     label::<Hlist![a, g, e], _>(3)
+    ///     label!((n, a, m, e), "joe"),
+    ///     label!((a, g, e), 3)
     /// ];
     ///
     /// let unlabelled = labelled_hlist.into_unlabelled();
@@ -353,171 +245,41 @@ macro_rules! type_string {
 }
 
 #[macro_export]
-macro_rules! label_new {
-    (($($repeated: ty),*), $value: expr) => {
-        $crate::labelled::build_label_new::<Hlist!($($repeated),*),_>($value, type_string!($($repeated),*))
-    };
-    // trailing comma case
-    (($($repeated: ty,)*), $value: expr) => {
-        label_new!( ($($repeated),*), $value )
-    };
+macro_rules! label {
     // We are provided a stable name
     (($($repeated: ty),*), $value: expr, $name: expr) => {
-        $crate::labelled::build_label_new::<Hlist!($($repeated),*),_>($value, $name)
+        $crate::labelled::label_with_name::<Hlist!($($repeated),*),_>($value, $name)
     };
-    // trailing comma case
+    // No name provided, trailing comma types case
     (($($repeated: ty,)*), $value: expr, $name: expr) => {
-        label_new!( ($($repeated),*), $value, $name )
+        label!( ($($repeated),*), $value, $name )
+    };
+    // No name provided
+    (($($repeated: ty),*), $value: expr) => {
+        label!( ($($repeated),*), $value, type_string!($($repeated),*))
+    };
+    // No name provided, trailing comma types case
+    (($($repeated: ty,)*), $value: expr) => {
+        label!( ($($repeated),*), $value )
     }
-
 }
 
 #[test]
 fn test_label_new_building() {
-    let l1 = label_new!((a, b, c), 3);
+    let l1 = label!((a, b, c), 3);
     assert_eq!(l1.value, 3);
     assert_eq!(l1.name, "abc");
-    let l2 = label_new!((a, b, c,), 3);
+    let l2 = label!((a, b, c,), 3);
     assert_eq!(l2.value, 3);
     assert_eq!(l2.name, "abc");
 
     // test named
-    let l3 = label_new!((a,b,c), 3, "nope");
+    let l3 = label!((a,b,c), 3, "nope");
     assert_eq!(l3.value, 3);
     assert_eq!(l3.name, "nope");
-    let l4 = label_new!((a,b,c,), 3, "nope");
+    let l4 = label!((a,b,c,), 3, "nope");
     assert_eq!(l4.value, 3);
     assert_eq!(l4.name, "nope");
-}
-
-
-
-/// Holds logic internal to this module.
-///
-/// Do not use any of these traits or methods directly, as they may change or disappear at any time!
-mod internal {
-
-    use super::*;
-
-    /// Trait for getting the runtime String representation for a type
-    ///
-    /// DO NOT implement this trait yourself unless you know what you are doing.
-    pub trait HasRuntimeString {
-        fn get_string() -> String;
-    }
-
-    impl HasRuntimeString for HNil {
-        fn get_string() -> String { "".to_string() }
-    }
-
-    impl <Char, Tail> HasRuntimeString for HCons<Char, Tail>
-        where Char: AsStaticStr,
-              Tail: HasRuntimeString {
-        fn get_string() -> String {
-            format!("{}{}", <Char as AsStaticStr>::get_char(), <Tail as HasRuntimeString>::get_string() )
-        }
-    }
-
-    // Decoder states
-    #[derive(Eq, PartialEq)]
-    #[doc(hidden)]
-    enum UnicodeDecoderState {
-        // Not processing unicode
-        Inactive,
-        // Just stepped into a unicode block of chars
-        JustStarted,
-        // Working on the current block of unicode chars
-        BuildingUnicodeCodepoint,
-    }
-
-    const UNICODE_BEGINS_CHAR: char = '{';
-    const UNICODE_ENDING_CHAR: char = '}';
-    const UNICODE_CODEPOINT_START: char = 'u';
-    const VALID_HEX_CHARS: &'static [char] = &['0','1','2','3','4','5','6','7','8','9', 'A','B','C','D','E','F', 'a','b','c','d','e','f'];
-
-    /// [DO NOT call this method] Given a String, tries to figure out if there are sequences
-    /// inside that are encoded as unicode, according to Frunk rules for type-level Strings.
-    ///
-    /// This inherently makes a lot of assumptions, one of which is that it will not fail ;)
-    /// The other is about how different names are encoded into type-level strings, and then
-    /// encoded into type-level unicode.
-    ///
-    /// For more details, see the test immediately following
-    pub fn decode_unicode(s_in: String) -> String {
-        if !s_in.contains(UNICODE_BEGINS_CHAR) && !s_in.contains(UNICODE_ENDING_CHAR){
-            s_in
-        } else {
-            let mut state = UnicodeDecoderState::Inactive;
-            let mut final_string = String::new();
-            let mut hex_buffer = String::new();
-            let mut u16_buffer: Vec<u16> = vec![];
-            for c in s_in.chars() {
-                if c == UNICODE_BEGINS_CHAR {
-                    state = UnicodeDecoderState::JustStarted;
-                } else if state == UnicodeDecoderState::JustStarted && c == UNICODE_CODEPOINT_START {
-                    // Start building
-                    state = UnicodeDecoderState::BuildingUnicodeCodepoint;
-                } else if state == UnicodeDecoderState::BuildingUnicodeCodepoint && c == UNICODE_CODEPOINT_START {
-                    // Just finished a codepoint, so convert the hex to u16,
-                    // put it into the u16 buffer and clear the hex buffer
-                    let as_hex = hex_str_to_u16(&hex_buffer[..]);
-                    u16_buffer.push(as_hex);
-                    hex_buffer = String::new();
-                } else if c == UNICODE_ENDING_CHAR {
-                    // We finished the whole block
-
-                    // Convert what's left in the hex buffer to u16,
-                    // push it into the u16 buffer, and clear the hex buffer
-                    let as_u16 = hex_str_to_u16(&hex_buffer[..]);
-                    u16_buffer.push(as_u16);
-                    hex_buffer = String::new();
-
-                    // Turn the whole u16 buffer into a single String
-                    let new_char = u16_vec_to_string(&u16_buffer[..]);
-                    // Push the newly minted char into the final string, an reset
-                    // buffer and state
-                    final_string = format!("{}{}", final_string, new_char);
-                    u16_buffer = vec![];
-                    state = UnicodeDecoderState::Inactive;
-                } else if state == UnicodeDecoderState::BuildingUnicodeCodepoint && VALID_HEX_CHARS.contains(&c) {
-                    hex_buffer.push(c);
-                } else if state != UnicodeDecoderState::Inactive {
-                    // Something went wrong, let's try to salvage the hex_buffer and reset state
-                    final_string = format!("{}{}", final_string, hex_buffer);
-                    hex_buffer = String::new();
-                    u16_buffer = vec![];
-                    state = UnicodeDecoderState::Inactive;
-                } else {
-                    final_string.push(c);
-                }
-            }
-            final_string
-        }
-    }
-
-    #[test]
-    fn test_decode_unicode(){
-        let s = "John_Appleby_123456";
-        let processed = decode_unicode(s.to_string());
-        assert_eq!(processed, s.to_string());
-
-        let has_unicode = "John_appleby_{u2764ufe0f}_happy";
-        let processed_unicode = decode_unicode(has_unicode.to_string());
-        assert_eq!(processed_unicode, "John_appleby_\u{2764}\u{fe0f}_happy");
-
-        let all_letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789";
-        let processed_letters = decode_unicode(all_letters.to_string());
-        assert_eq!(processed_letters, all_letters.to_string())
-    }
-
-    fn hex_str_to_u16(hex_str: &str) -> u16 {
-        u16::from_str_radix(hex_str, 16).unwrap()
-    }
-
-    fn u16_vec_to_string(v: &[u16]) -> String {
-        String::from_utf16(v).unwrap()
-    }
-
 }
 
 #[cfg(test)]
@@ -526,16 +288,16 @@ mod tests {
 
     #[test]
     fn test_field_construction() {
-        let f1 = label::<Hlist!(a, g, e), i32>(3);
-        let f2 = label::<Hlist!(a, g, e), i32>(3);
+        let f1 = label!((a, g, e), 3);
+        let f2 = label!((a, g, e), 3);
         assert_eq!(f1, f2)
     }
 
     #[test]
     fn test_anonymous_record_useage() {
         let record = hlist![
-            label::<Hlist![n, a, m, e], _>("Joe"),
-            label::<Hlist![a, g, e], _>(30)
+            label!((n, a, m, e), "Joe"),
+            label!((a, g, e), 30)
         ];
         let (name, _): (Labelled<Hlist![n, a, m, e], _>, _) = record.pluck();
         assert_eq!(name.value, "Joe")
@@ -544,17 +306,15 @@ mod tests {
     #[test]
     fn test_unlabelling() {
         let labelled_hlist = hlist![
-            label::<Hlist![n, a, m, e], &str>("joe"),
-            label::<Hlist![a, g, e], i32>(3)];
+            label!((n, a, m, e), "joe"),
+            label!((a, g, e), 3)];
         let unlabelled = labelled_hlist.into_unlabelled();
         assert_eq!(unlabelled, hlist!["joe", 3])
     }
 
     #[test]
-    fn test_get_string() {
-        let labelled = label::<Hlist![n, a, m, e, _1, _2, _3], &str>("joe");
-        assert_eq!(labelled.name(), "name123".to_string());
-
-        println!("YO {:?}", labelled)
+    fn test_name() {
+        let labelled = label!((n, a, m, e), "joe");
+        assert_eq!(labelled.name, "name")
     }
 }

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -217,56 +217,48 @@ impl<Label, Value, Tail> IntoUnlabelled for HCons<Labelled<Label, Value>, Tail>
     }
 }
 
-/// Returns a string resulting from the concatenation of the types provided
+/// Used for creating a Labelled value
+///
+/// There are two forms of this macro:
+///
+/// * Create an instance of the `Labelled` struct with the name
+///   set to the the concatenation of the types passed in the
+///   tuple used as the first argument.
 ///
 /// ```
 /// # #[macro_use] extern crate frunk_core;
 /// # use frunk_core::labelled::*;
 /// # use frunk_core::hlist::*;
 /// # fn main() {
-/// assert_eq!(type_string!(a), "a");
-/// assert_eq!(type_string!(a,b,c,d), "abcd");
-/// assert_eq!(type_string!(a,b,c,d,), "abcd");
-/// assert_eq!(type_string!(), "")
+/// let labelled = label![(n,a,m,e), 30];
+/// assert_eq!(labelled.name, "name")
+/// # }
+/// ```
+///
+/// * Create an instance of the `Labelled` struct with a custom, name,
+///   passed as the last argument in the macro
+/// ```
+/// # #[macro_use] extern crate frunk_core;
+/// # use frunk_core::labelled::*;
+/// # use frunk_core::hlist::*;
+/// # fn main() {
+/// let labelled = label![(a,g,e), 30, "Age"];
+/// assert_eq!(labelled.name, "Age");
 /// # }
 /// ```
 #[macro_export]
-macro_rules! type_string {
-    // Nothing
-    () => { "" };
-
-    // Just a single item
-    ($single: ty) => {
-        stringify!($single)
-    };
-
-    ($($repeated: ty),+) => {
-        concat!($( type_string!($repeated)), * )
-    };
-    // Trailing comma case
-    ($($repeated: ty,)+) => {
-        type_string!($($repeated), *)
-    };
-
-}
-
-#[macro_export]
 macro_rules! label {
-    // We are provided a stable name
-    (($($repeated: ty),*), $value: expr, $name: expr) => {
-        $crate::labelled::label_with_name::<($($repeated),*),_>($name, $value)
-    };
-    // No name provided, trailing comma types case
-    (($($repeated: ty,)*), $value: expr, $name: expr) => {
-        label!( ($($repeated),*), $value, $name )
-    };
-    // No name provided
+    // No name provided and type is a tuple
     (($($repeated: ty),*), $value: expr) => {
-        label!( ($($repeated),*), $value, type_string!($($repeated),*))
+        label!( ($($repeated),*), $value, concat!( $(stringify!($repeated)),* ) )
     };
-    // No name provided, trailing comma types case
+    // No name provided and type is a tuple, but with trailing commas
     (($($repeated: ty,)*), $value: expr) => {
         label!( ($($repeated),*), $value )
+    };
+    // We are provided any type, with a stable name
+    ($name_type: ty, $value: expr, $name: expr) => {
+        $crate::labelled::label_with_name::<$name_type,_>($name, $value)
     }
 }
 

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -56,7 +56,7 @@ use std::fmt;
 ///     age: 30,
 /// };
 ///
-/// let s_user = <SavedUser as LabelledGeneric>::convert_from(n_user); // done
+/// let s_user = <SavedUser as LabelledGeneric>::sculpted_convert_from(n_user); // done
 /// ```
 pub trait LabelledGeneric {
     /// The labelled generic representation type

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -16,7 +16,7 @@
 /// # use frunk_core::labelled::*;
 /// # use frunk_core::hlist::*;
 /// # fn main() {
-/// let labelled = label![(n,a,m,e), "Lloyd"];
+/// let labelled = field![(n,a,m,e), "Lloyd"];
 /// assert_eq!(labelled.name, "name")
 /// # }
 /// ```
@@ -146,25 +146,25 @@ create_enums_for! { a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D 
 /// A Label contains a type-level Name, a runtime value, and
 /// a reference to a `&'static str` name.
 ///
-/// To construct one, use the `label!` macro.
+/// To construct one, use the `field!` macro.
 ///
 /// ```
 /// # #[macro_use] extern crate frunk_core;
 /// # use frunk_core::labelled::*;
 /// # use frunk_core::hlist::*;
 /// # fn main() {
-/// let labelled = label![(n,a,m,e), "joe"];
+/// let labelled = field![(n,a,m,e), "joe"];
 /// assert_eq!(labelled.name, "name")
 /// # }
 /// ```
 #[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
-pub struct Labelled<Name, Type> {
+pub struct Field<Name, Type> {
     name_type_holder: PhantomData<Name>,
     pub name: &'static str,
     pub value: Type,
 }
 
-impl <Name, Type> fmt::Debug for Labelled<Name, Type>
+impl <Name, Type> fmt::Debug for Field<Name, Type>
     where Type: fmt::Debug {
 
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -173,19 +173,19 @@ impl <Name, Type> fmt::Debug for Labelled<Name, Type>
     }
 }
 
-/// Returns a new label for a given value and custom name.
+/// Returns a new Field for a given value and custom name.
 ///
 /// If you don't want to provide a custom name and want to rely on the type you provide
-/// to build a name, then please use the label! macro.
+/// to build a name, then please use the field! macro.
 ///
 /// ```
 /// # use frunk_core::labelled::*;
-/// let l = label_with_name::<(n,a,m,e),_>("name", "joe");
+/// let l = field_with_name::<(n,a,m,e),_>("name", "joe");
 /// assert_eq!(l.value, "joe");
 /// assert_eq!(l.name, "name");
 /// ```
-pub fn label_with_name<Label, Value>(name: &'static str, value: Value) -> Labelled<Label, Value> {
-    Labelled {
+pub fn field_with_name<Label, Value>(name: &'static str, value: Value) -> Field<Label, Value> {
+    Field {
         name_type_holder: PhantomData,
         name: name,
         value: value,
@@ -207,8 +207,8 @@ pub trait IntoUnlabelled {
     /// # fn main() {
     ///
     /// let labelled_hlist = hlist![
-    ///     label!((n, a, m, e), "joe"),
-    ///     label!((a, g, e), 3)
+    ///     field!((n, a, m, e), "joe"),
+    ///     field!((a, g, e), 3)
     /// ];
     ///
     /// let unlabelled = labelled_hlist.into_unlabelled();
@@ -228,7 +228,7 @@ impl IntoUnlabelled for HNil {
 }
 
 /// Implementation when we have a non-empty HCons holding a label in its head
-impl<Label, Value, Tail> IntoUnlabelled for HCons<Labelled<Label, Value>, Tail>
+impl<Label, Value, Tail> IntoUnlabelled for HCons<Field<Label, Value>, Tail>
     where Tail: IntoUnlabelled
 {
     type Output = HCons<Value, <Tail as IntoUnlabelled>::Output>;
@@ -254,7 +254,7 @@ impl<Label, Value, Tail> IntoUnlabelled for HCons<Labelled<Label, Value>, Tail>
 /// # use frunk_core::labelled::*;
 /// # use frunk_core::hlist::*;
 /// # fn main() {
-/// let labelled = label![(n,a,m,e), "joe"];
+/// let labelled = field![(n,a,m,e), "joe"];
 /// assert_eq!(labelled.name, "name")
 /// # }
 /// ```
@@ -266,40 +266,40 @@ impl<Label, Value, Tail> IntoUnlabelled for HCons<Labelled<Label, Value>, Tail>
 /// # use frunk_core::labelled::*;
 /// # use frunk_core::hlist::*;
 /// # fn main() {
-/// let labelled = label![(a,g,e), 30, "Age"];
+/// let labelled = field![(a,g,e), 30, "Age"];
 /// assert_eq!(labelled.name, "Age");
 /// # }
 /// ```
 #[macro_export]
-macro_rules! label {
+macro_rules! field {
     // No name provided and type is a tuple
     (($($repeated: ty),*), $value: expr) => {
-        label!( ($($repeated),*), $value, concat!( $(stringify!($repeated)),* ) )
+        field!( ($($repeated),*), $value, concat!( $(stringify!($repeated)),* ) )
     };
     // No name provided and type is a tuple, but with trailing commas
     (($($repeated: ty,)*), $value: expr) => {
-        label!( ($($repeated),*), $value )
+        field!( ($($repeated),*), $value )
     };
     // We are provided any type, with a stable name
     ($name_type: ty, $value: expr, $name: expr) => {
-        $crate::labelled::label_with_name::<$name_type,_>($name, $value)
+        $crate::labelled::field_with_name::<$name_type,_>($name, $value)
     }
 }
 
 #[test]
 fn test_label_new_building() {
-    let l1 = label!((a, b, c), 3);
+    let l1 = field!((a, b, c), 3);
     assert_eq!(l1.value, 3);
     assert_eq!(l1.name, "abc");
-    let l2 = label!((a, b, c,), 3);
+    let l2 = field!((a, b, c,), 3);
     assert_eq!(l2.value, 3);
     assert_eq!(l2.name, "abc");
 
     // test named
-    let l3 = label!((a,b,c), 3, "nope");
+    let l3 = field!((a,b,c), 3, "nope");
     assert_eq!(l3.value, 3);
     assert_eq!(l3.name, "nope");
-    let l4 = label!((a,b,c,), 3, "nope");
+    let l4 = field!((a,b,c,), 3, "nope");
     assert_eq!(l4.value, 3);
     assert_eq!(l4.name, "nope");
 }
@@ -310,33 +310,33 @@ mod tests {
 
     #[test]
     fn test_field_construction() {
-        let f1 = label!((a, g, e), 3);
-        let f2 = label!((a, g, e), 3);
+        let f1 = field!((a, g, e), 3);
+        let f2 = field!((a, g, e), 3);
         assert_eq!(f1, f2)
     }
 
     #[test]
     fn test_anonymous_record_useage() {
         let record = hlist![
-            label!((n, a, m, e), "Joe"),
-            label!((a, g, e), 30)
+            field!((n, a, m, e), "Joe"),
+            field!((a, g, e), 30)
         ];
-        let (name, _): (Labelled<(n, a, m, e), _>, _) = record.pluck();
+        let (name, _): (Field<(n, a, m, e), _>, _) = record.pluck();
         assert_eq!(name.value, "Joe")
     }
 
     #[test]
     fn test_unlabelling() {
         let labelled_hlist = hlist![
-            label!((n, a, m, e), "joe"),
-            label!((a, g, e), 3)];
+            field!((n, a, m, e), "joe"),
+            field!((a, g, e), 3)];
         let unlabelled = labelled_hlist.into_unlabelled();
         assert_eq!(unlabelled, hlist!["joe", 3])
     }
 
     #[test]
     fn test_name() {
-        let labelled = label!((n, a, m, e), "joe");
+        let labelled = field!((n, a, m, e), "joe");
         assert_eq!(labelled.name, "name")
     }
 }

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -153,7 +153,14 @@ impl <Name, Type> fmt::Debug for Labelled<Name, Type>
 ///
 /// If you don't want to provide a custom name and want to rely on the type you provide
 /// to build a name, then please use the label! macro.
-pub fn label_with_name<Label, Value>(value: Value, name: &'static str) -> Labelled<Label, Value> {
+///
+/// ```
+/// # use frunk_core::labelled::*;
+/// let l = label_with_name::<(n,a,m,e),_>("name", "joe");
+/// assert_eq!(l.value, "joe");
+/// assert_eq!(l.name, "name");
+/// ```
+pub fn label_with_name<Label, Value>(name: &'static str, value: Value) -> Labelled<Label, Value> {
     Labelled {
         name_type_holder: PhantomData,
         name: name,
@@ -247,7 +254,7 @@ macro_rules! type_string {
 macro_rules! label {
     // We are provided a stable name
     (($($repeated: ty),*), $value: expr, $name: expr) => {
-        $crate::labelled::label_with_name::<($($repeated),*),_>($value, $name)
+        $crate::labelled::label_with_name::<($($repeated),*),_>($name, $value)
     };
     // No name provided, trailing comma types case
     (($($repeated: ty,)*), $value: expr, $name: expr) => {

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -230,11 +230,14 @@ pub struct Labelled<Name, Type> {
 /// Useful so that users don't need to deal with PhantomData directly.
 ///
 /// ```
+/// # #[macro_use] extern crate frunk_core;
 /// # use frunk_core::labelled::*;
-/// let f1 = label::<(a, g, e), i32>(3);
-/// let f2 = label::<(a, g, e), i32>(3);
+/// # use frunk_core::hlist::*;
+/// # fn main() {
+/// let f1 = label::<Hlist![a, g, e], i32>(3);
+/// let f2 = label::<Hlist![a, g, e], i32>(3);
 /// assert_eq!(f1, f2)
-///
+/// # }
 /// ```
 pub fn label<Label, Value>(value: Value) -> Labelled<Label, Value> {
     Labelled {
@@ -258,8 +261,8 @@ pub trait IntoUnlabelled {
     /// # fn main() {
     ///
     /// let labelled_hlist = hlist![
-    ///     label::<(n, a, m, e), _>("joe"),
-    ///     label::<(a, g, e), _>(3)
+    ///     label::<Hlist![n, a, m, e], _>("joe"),
+    ///     label::<Hlist![a, g, e], _>(3)
     /// ];
     ///
     /// let unlabelled = labelled_hlist.into_unlabelled();
@@ -306,10 +309,10 @@ mod tests {
     #[test]
     fn test_anonymous_record_useage() {
         let record = hlist![
-            label::<(n, a, m, e), _>("Joe"),
-            label::<(a, g, e), _>(30)
+            label::<Hlist![n, a, m, e], _>("Joe"),
+            label::<Hlist![a, g, e], _>(30)
         ];
-        let (name, _): (Labelled<(n, a, m, e), _>, _) = record.pluck();
+        let (name, _): (Labelled<Hlist![n, a, m, e], _>, _) = record.pluck();
         assert_eq!(name.value, "Joe")
     }
 

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -10,6 +10,16 @@
 //! users to use LabelledGeneric without using universal function call syntax.
 //!
 //! In addition, this module holds macro-generated enums that map to letters in field names (identifiers).
+//!
+/// ```
+/// # #[macro_use] extern crate frunk_core;
+/// # use frunk_core::labelled::*;
+/// # use frunk_core::hlist::*;
+/// # fn main() {
+/// let labelled = label![(n,a,m,e), "Lloyd"];
+/// assert_eq!(labelled.name, "name")
+/// # }
+/// ```
 
 use std::marker::PhantomData;
 use hlist::*;
@@ -133,6 +143,20 @@ macro_rules! create_enums_for {
 // Add more as needed.
 create_enums_for! { a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D E F G H I J K L M N O P Q R S T U V W X Y Z __ _1 _2 _3 _4 _5 _6 _7 _8 _9 _0 }
 
+/// A Label contains a type-level Name, a runtime value, and
+/// a reference to a `&'static str` name.
+///
+/// To construct one, use the `label!` macro.
+///
+/// ```
+/// # #[macro_use] extern crate frunk_core;
+/// # use frunk_core::labelled::*;
+/// # use frunk_core::hlist::*;
+/// # fn main() {
+/// let labelled = label![(n,a,m,e), "joe"];
+/// assert_eq!(labelled.name, "name")
+/// # }
+/// ```
 #[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
 pub struct Labelled<Name, Type> {
     name_type_holder: PhantomData<Name>,
@@ -230,7 +254,7 @@ impl<Label, Value, Tail> IntoUnlabelled for HCons<Labelled<Label, Value>, Tail>
 /// # use frunk_core::labelled::*;
 /// # use frunk_core::hlist::*;
 /// # fn main() {
-/// let labelled = label![(n,a,m,e), 30];
+/// let labelled = label![(n,a,m,e), "joe"];
 /// assert_eq!(labelled.name, "name")
 /// # }
 /// ```

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_derives"
-version = "0.0.8"
+version = "0.0.9"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "frunk_derives contains the custom derivations for certain traits in Frunk."
 license = "MIT"
@@ -16,4 +16,4 @@ quote = "0.3.12"
 
 [dependencies.frunk_core]
 path = "../core"
-version = "0.0.7"
+version = "0.0.8"

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -159,7 +159,7 @@ fn build_labelled_constr_for(field: &Field) -> Tokens {
     let field_type = field.ty.clone();
     let field_name = field.ident.clone();
     let field_name_str = field.ident.clone().unwrap().as_ref().to_string();
-    quote! { ::frunk_core::labelled::label_with_name::<#name_as_type, #field_type>(#field_name, #field_name_str) }
+    quote! { ::frunk_core::labelled::label_with_name::<#name_as_type, #field_type>(#field_name_str, #field_name) }
 }
 
 /// Given a struct name, and a number of Idents that act as accessors and struct member

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -85,7 +85,7 @@ fn build_labelled_type_for(field: &Field) -> Tokens {
 /// Given an Ident returns an AST for its type level representation based on the
 /// enums generated in frunk_core::labelled.
 ///
-/// For example, given first_name, returns an AST for (f,i,r,s,t,__,n,a,m,e)
+/// For example, given first_name, returns an AST for Hlist!(f,i,r,s,t,__,n,a,m,e)
 fn build_type_level_name_for(ident: &Ident) -> Tokens {
     let name = ident.as_ref();
     let name_as_idents: Vec<Ident> = name.chars().flat_map(|c| encode_as_ident(&c)).collect();
@@ -168,7 +168,7 @@ fn build_labelled_hcons_constr(fields: &Vec<Field>) -> Tokens {
 ///
 /// This calls a method in frunk_core::labelled called "label"
 ///
-/// For example, given a field "age" of type i32, returns: label::<(a,g,e), i32>(age)
+/// For example, given a field "age" of type i32, returns: label::<Hlist!(a,g,e), i32>(age)
 fn build_labelled_constr_for(field: &Field) -> Tokens {
     let name_as_type = build_type_level_name_for(&field.clone().ident.unwrap());
     let field_type = field.ty.clone();

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -166,14 +166,16 @@ fn build_labelled_hcons_constr(fields: &Vec<Field>) -> Tokens {
 /// Given a field, returns an AST for calling the Labelled constructor that holds its
 /// value.
 ///
-/// This calls a method in frunk_core::labelled called "label"
+/// This calls a method in frunk_core::labelled called "label_with_name", filling in the value and the
+/// field name.
 ///
-/// For example, given a field "age" of type i32, returns: label::<Hlist!(a,g,e), i32>(age)
+/// For example, given a field "age" of type i32, returns: label_with_name::<Hlist!(a,g,e), i32>(age, "age")
 fn build_labelled_constr_for(field: &Field) -> Tokens {
     let name_as_type = build_type_level_name_for(&field.clone().ident.unwrap());
     let field_type = field.ty.clone();
     let field_name = field.ident.clone();
-    quote! { ::frunk_core::labelled::label::<#name_as_type, #field_type>(#field_name) }
+    let field_name_str = field.ident.clone().unwrap().as_ref().to_string();
+    quote! { ::frunk_core::labelled::label_with_name::<#name_as_type, #field_type>(#field_name, #field_name_str) }
 }
 
 /// Given a struct name, and a number of Idents that act as accessors and struct member

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -92,23 +92,7 @@ fn build_type_level_name_for(ident: &Ident) -> Tokens {
     let name_as_tokens: Vec<Tokens> = name_as_idents.iter().map(|ident| {
         quote! { ::frunk_core::labelled::#ident }
     }).collect();
-    build_hcons_type(&name_as_tokens)
-}
-
-fn build_hcons_type(idents: &Vec<Tokens>) -> Tokens {
-    match idents.len() {
-        0 => quote! { ::frunk_core::hlist::HNil },
-        1 => {
-            let h = idents[0].clone();
-            quote! { ::frunk_core::hlist::HCons<#h, ::frunk_core::hlist::HNil> }
-        },
-        _ => {
-            let h = idents[0].clone();
-            let tail = idents[1..].to_vec();
-            let tail_type = build_hcons_type(&tail);
-            quote! { ::frunk_core::hlist::HCons<#h, #tail_type> }
-        }
-    }
+    quote! { (#(#name_as_tokens),*) }
 }
 
 /// Given a char, encodes it as a vector of Ident

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -153,7 +153,7 @@ fn build_labelled_hcons_constr(fields: &Vec<Field>) -> Tokens {
 /// This calls a method in frunk_core::labelled called "label_with_name", filling in the value and the
 /// field name.
 ///
-/// For example, given a field "age" of type i32, returns: label_with_name::<Hlist!(a,g,e), i32>(age, "age")
+/// For example, given a field "age" of type i32, returns: label_with_name::<(a,g,e), i32>(age, "age")
 fn build_labelled_constr_for(field: &Field) -> Tokens {
     let name_as_type = build_type_level_name_for(&field.clone().ident.unwrap());
     let field_type = field.ty.clone();

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -10,7 +10,7 @@ const ALPHA_CHARS: &'static [char] = &['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', '
 const UNDERSCORE_CHARS: &'static [char] = &['_', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
 
 /// Given an AST, returns an implementation of Generic using HList with
-/// Labelled (see frunk_core::labelled) elements
+/// Field (see frunk_core::labelled) elements
 ///
 /// Only works with Structs and Tuple Structs
 pub fn impl_labelled_generic(input: TokenStream) -> Tokens {
@@ -73,7 +73,7 @@ fn build_labelled_repr(fields: &Vec<Field>) -> Tokens {
     }
 }
 
-/// Given a field, returns an AST for its Labelled (see labelled module in core) type,
+/// Given a field, returns an AST for its Field (see labelled module in core) type,
 /// which holds its name (or an approximation) and type.
 fn build_labelled_type_for(field: &Field) -> Tokens {
     let ident = field.clone().ident.unwrap(); // this method is for labelled structs only
@@ -125,7 +125,7 @@ fn encode_as_ident(c: &char) -> Vec<Ident> {
 
 /// Given a number of Idents that act as accessors and struct member
 /// names, returns an AST representing how to construct an HList containing
-/// Labelled values.
+/// Field values.
 ///
 /// Assumes that there are bindings in the immediate environment with those names that
 /// are bound to properly-typed values.
@@ -134,12 +134,12 @@ fn build_labelled_hcons_constr(fields: &Vec<Field>) -> Tokens {
         0 => quote! { ::frunk_core::hlist::HNil },
         1 => {
             let field = fields[0].clone();
-            let labelled_constructor = build_labelled_constr_for(&field);
+            let labelled_constructor = build_field_constr_for(&field);
             quote! { ::frunk_core::hlist::HCons{ head: #labelled_constructor, tail: ::frunk_core::hlist::HNil } }
         },
         _ => {
             let field = fields[0].clone();
-            let labelled_constructor = build_labelled_constr_for(&field);
+            let labelled_constructor = build_field_constr_for(&field);
             let tail = fields[1..].to_vec();
             let hlist_tail = build_labelled_hcons_constr(&tail);
             quote! { ::frunk_core::hlist::HCons{ head: #labelled_constructor, tail: #hlist_tail }}
@@ -147,14 +147,14 @@ fn build_labelled_hcons_constr(fields: &Vec<Field>) -> Tokens {
     }
 }
 
-/// Given a field, returns an AST for calling the Labelled constructor that holds its
+/// Given a field, returns an AST for calling the Field constructor that holds its
 /// value.
 ///
 /// This calls a method in frunk_core::labelled called "field_with_name", filling in the value and the
 /// field name.
 ///
 /// For example, given a field "age" of type i32, returns: field_with_name::<(a,g,e), i32>(age, "age")
-fn build_labelled_constr_for(field: &Field) -> Tokens {
+fn build_field_constr_for(field: &Field) -> Tokens {
     let name_as_type = build_type_level_name_for(&field.clone().ident.unwrap());
     let field_type = field.ty.clone();
     let field_name = field.ident.clone();
@@ -166,7 +166,7 @@ fn build_labelled_constr_for(field: &Field) -> Tokens {
 /// names, returns an AST representing how to construct said struct.
 ///
 /// Assumes that there are bindings in the immediate environment with those names that
-/// are bound to Labelled values.
+/// are bound to Field values.
 ///
 /// The opposite of build_labelled_hcons_constr
 fn build_new_labelled_struct_constr(struct_name: &Ident, bindnames: &Vec<Ident>) -> Tokens {

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -79,7 +79,7 @@ fn build_labelled_type_for(field: &Field) -> Tokens {
     let ident = field.clone().ident.unwrap(); // this method is for labelled structs only
     let name_as_type = build_type_level_name_for(&ident);
     let ref field_type = field.ty;
-    quote! { ::frunk_core::labelled::Labelled<#name_as_type, #field_type> }
+    quote! { ::frunk_core::labelled::Field<#name_as_type, #field_type> }
 }
 
 /// Given an Ident returns an AST for its type level representation based on the
@@ -150,16 +150,16 @@ fn build_labelled_hcons_constr(fields: &Vec<Field>) -> Tokens {
 /// Given a field, returns an AST for calling the Labelled constructor that holds its
 /// value.
 ///
-/// This calls a method in frunk_core::labelled called "label_with_name", filling in the value and the
+/// This calls a method in frunk_core::labelled called "field_with_name", filling in the value and the
 /// field name.
 ///
-/// For example, given a field "age" of type i32, returns: label_with_name::<(a,g,e), i32>(age, "age")
+/// For example, given a field "age" of type i32, returns: field_with_name::<(a,g,e), i32>(age, "age")
 fn build_labelled_constr_for(field: &Field) -> Tokens {
     let name_as_type = build_type_level_name_for(&field.clone().ident.unwrap());
     let field_type = field.ty.clone();
     let field_name = field.ident.clone();
     let field_name_str = field.ident.clone().unwrap().as_ref().to_string();
-    quote! { ::frunk_core::labelled::label_with_name::<#name_as_type, #field_type>(#field_name_str, #field_name) }
+    quote! { ::frunk_core::labelled::field_with_name::<#name_as_type, #field_type>(#field_name_str, #field_name) }
 }
 
 /// Given a struct name, and a number of Idents that act as accessors and struct member

--- a/derives/src/lib.rs
+++ b/derives/src/lib.rs
@@ -35,7 +35,7 @@ pub fn generic(input: TokenStream) -> TokenStream {
     gen.parse().unwrap()
 }
 
-/// Derives a Generic instance based on Labelled + HList for
+/// Derives a Generic instance based on Field + HList for
 /// a given Struct (Tuple Structs not supported because they have
 /// no labels)
 ///

--- a/tests/derivation_tests.rs
+++ b/tests/derivation_tests.rs
@@ -1,4 +1,3 @@
-#![recursion_limit="128"]
 extern crate frunk;
 #[macro_use] // for the hlist macro
 extern crate frunk_core;

--- a/tests/derivation_tests.rs
+++ b/tests/derivation_tests.rs
@@ -132,6 +132,18 @@ fn test_struct_from_labelled_generic() {
 }
 
 #[test]
+fn test_labelled_generic_names(){
+    let u = NewUser {
+        first_name: "Humpty",
+        last_name: "Drumpty",
+        age: 3,
+    };
+    let h = into_labelled_generic(u);
+    let l_name: &Labelled<(l,a,s,t,__,n,a,m,e), _> = h.get();
+    assert_eq!(l_name.name, "last_name")
+}
+
+#[test]
 fn test_struct_into_labelled_generic() {
     let u = NewUser {
         first_name: "Humpty",

--- a/tests/derivation_tests.rs
+++ b/tests/derivation_tests.rs
@@ -119,9 +119,9 @@ fn test_struct_conversion_round_trip() {
 
 #[test]
 fn test_struct_from_labelled_generic() {
-    let h = hlist![label!((f, i, r, s, t, __, n, a, m, e), "Humpty"),
-                   label!((l, a, s, t, __, n, a, m, e), "Drumpty"),
-                   label!((a, g, e), 3)];
+    let h = hlist![field!((f, i, r, s, t, __, n, a, m, e), "Humpty"),
+                   field!((l, a, s, t, __, n, a, m, e), "Drumpty"),
+                   field!((a, g, e), 3)];
     let u: NewUser = from_labelled_generic(h);
     assert_eq!(u,
                NewUser {
@@ -139,8 +139,10 @@ fn test_labelled_generic_names(){
         age: 3,
     };
     let h = into_labelled_generic(u);
-    let l_name: &Labelled<(l,a,s,t,__,n,a,m,e), _> = h.get();
-    assert_eq!(l_name.name, "last_name")
+    let l_name_field: &Field<(l,a,s,t,__,n,a,m,e), _> = h.get();
+    assert_eq!(l_name_field.name, "last_name");
+    let f_name_field: &Field<(f,i,r,s,t,__,n,a,m,e), _> = h.get();
+    assert_eq!(f_name_field.name, "first_name")
 }
 
 #[test]
@@ -152,9 +154,9 @@ fn test_struct_into_labelled_generic() {
     };
     let h = into_labelled_generic(u);
     assert_eq!(h,
-               hlist![label!((f, i, r, s, t, __, n, a, m, e), "Humpty", "first_name"),
-                      label!((l, a, s, t, __, n, a, m, e),"Drumpty", "last_name"),
-                      label!((a, g, e), 3)]);
+               hlist![field!((f, i, r, s, t, __, n, a, m, e), "Humpty", "first_name"),
+                      field!((l, a, s, t, __, n, a, m, e),"Drumpty", "last_name"),
+                      field!((a, g, e), 3)]);
 }
 
 #[test]

--- a/tests/derivation_tests.rs
+++ b/tests/derivation_tests.rs
@@ -1,3 +1,4 @@
+#![recursion_limit="128"]
 extern crate frunk;
 #[macro_use] // for the hlist macro
 extern crate frunk_core;
@@ -119,9 +120,9 @@ fn test_struct_conversion_round_trip() {
 
 #[test]
 fn test_struct_from_labelled_generic() {
-    let h = hlist![label::<(f, i, r, s, t, __, n, a, m, e), &str>("Humpty"),
-                   label::<(l, a, s, t, __, n, a, m, e), &str>("Drumpty"),
-                   label::<(a, g, e), usize>(3)];
+    let h = hlist![label::<Hlist!(f, i, r, s, t, __, n, a, m, e), &str>("Humpty"),
+                   label::<Hlist!(l, a, s, t, __, n, a, m, e), &str>("Drumpty"),
+                   label::<Hlist!(a, g, e), usize>(3)];
     let u: NewUser = from_labelled_generic(h);
     assert_eq!(u,
                NewUser {
@@ -140,9 +141,9 @@ fn test_struct_into_labelled_generic() {
     };
     let h = into_labelled_generic(u);
     assert_eq!(h,
-               hlist![label::<(f, i, r, s, t, __, n, a, m, e), &str>("Humpty"),
-                      label::<(l, a, s, t, __, n, a, m, e), &str>("Drumpty"),
-                      label::<(a, g, e), usize>(3)]);
+               hlist![label::<Hlist!(f, i, r, s, t, __, n, a, m, e), &str>("Humpty"),
+                      label::<Hlist!(l, a, s, t, __, n, a, m, e), &str>("Drumpty"),
+                      label::<Hlist!(a, g, e), usize>(3)]);
 }
 
 #[test]

--- a/tests/derivation_tests.rs
+++ b/tests/derivation_tests.rs
@@ -120,9 +120,9 @@ fn test_struct_conversion_round_trip() {
 
 #[test]
 fn test_struct_from_labelled_generic() {
-    let h = hlist![label::<Hlist!(f, i, r, s, t, __, n, a, m, e), &str>("Humpty"),
-                   label::<Hlist!(l, a, s, t, __, n, a, m, e), &str>("Drumpty"),
-                   label::<Hlist!(a, g, e), usize>(3)];
+    let h = hlist![label!((f, i, r, s, t, __, n, a, m, e), "Humpty"),
+                   label!((l, a, s, t, __, n, a, m, e), "Drumpty"),
+                   label!((a, g, e), 3)];
     let u: NewUser = from_labelled_generic(h);
     assert_eq!(u,
                NewUser {
@@ -141,9 +141,9 @@ fn test_struct_into_labelled_generic() {
     };
     let h = into_labelled_generic(u);
     assert_eq!(h,
-               hlist![label::<Hlist!(f, i, r, s, t, __, n, a, m, e), &str>("Humpty"),
-                      label::<Hlist!(l, a, s, t, __, n, a, m, e), &str>("Drumpty"),
-                      label::<Hlist!(a, g, e), usize>(3)]);
+               hlist![label!((f, i, r, s, t, __, n, a, m, e), "Humpty", "first_name"),
+                      label!((l, a, s, t, __, n, a, m, e),"Drumpty", "last_name"),
+                      label!((a, g, e), 3)]);
 }
 
 #[test]


### PR DESCRIPTION
* Renames `Labelled` to `Field` to better reflect Shapeless naming conventions
* `Field` now holds a static `name` reference for retrieval of the name at runtime
* Introduce `field!` macro that will create a static string from the type passed in and use it to instantiate a `field`
* Add more docs, tests, and benchmarks