### PR TITLE
Improve 'frunk', 'frunk_core', and 'frunk_derives' package metadata.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Frunk provides developers with a number of functional programming
 license = "MIT"
 documentation = "https://docs.rs/frunk"
 repository = "https://github.com/lloydmeta/frunk"
-keywords = [ "HList", "Generic", "Validated", "Semigroup", "Monoid"]
+keywords = ["Frunk", "HList", "Generic", "Validated", "Semigroup", "Monoid"]
 
 [badges]
 travis-ci = { repository = "lloydmeta/frunk" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,12 @@ version = "0.1.19"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk provides developers with a number of functional programming tools like HList, Generic, LabelledGeneric, Validated, Monoid, Semigroup and friends."
 license = "MIT"
-homepage = "https://github.com/lloydmeta/frunk"
+documentation = "https://docs.rs/frunk/0.1.19/frunk/"
+repository = "https://github.com/lloydmeta/frunk"
 keywords = [ "HList", "Generic", "Validated", "Semigroup", "Monoid"]
+
+[badges]
+travis-ci = { repository = "lloydmeta/frunk" }
 
 [dev-dependencies]
 time = "0.1.36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.19"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk provides developers with a number of functional programming tools like HList, Generic, LabelledGeneric, Validated, Monoid, Semigroup and friends."
 license = "MIT"
-documentation = "https://docs.rs/frunk/0.1.19/frunk/"
+documentation = "https://docs.rs/frunk"
 repository = "https://github.com/lloydmeta/frunk"
 keywords = [ "HList", "Generic", "Validated", "Semigroup", "Monoid"]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,7 +6,7 @@ description = "Frunk core provides developers with HList and Generic"
 license = "MIT"
 documentation = "https://docs.rs/frunk_core"
 repository = "https://github.com/lloydmeta/frunk"
-keywords = [ "HList", "Generic", "LabelledGeneric"]
+keywords = ["Frunk", "HList", "Generic", "LabelledGeneric"]
 
 [badges]
 travis-ci = { repository = "lloydmeta/frunk" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,5 +4,9 @@ version = "0.0.9"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk core provides developers with HList and Generic"
 license = "MIT"
-homepage = "https://github.com/lloydmeta/frunk"
+documentation = "https://docs.rs/frunk_core/0.0.9/frunk_core/"
+repository = "https://github.com/lloydmeta/frunk"
 keywords = [ "HList", "Generic"]
+
+[badges]
+travis-ci = { repository = "lloydmeta/frunk" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,7 +6,7 @@ description = "Frunk core provides developers with HList and Generic"
 license = "MIT"
 documentation = "https://docs.rs/frunk_core"
 repository = "https://github.com/lloydmeta/frunk"
-keywords = [ "HList", "Generic"]
+keywords = [ "HList", "Generic", "LabelledGeneric"]
 
 [badges]
 travis-ci = { repository = "lloydmeta/frunk" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.9"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk core provides developers with HList and Generic"
 license = "MIT"
-documentation = "https://docs.rs/frunk_core/0.0.9/frunk_core/"
+documentation = "https://docs.rs/frunk_core"
 repository = "https://github.com/lloydmeta/frunk"
 keywords = [ "HList", "Generic"]
 

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.10"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "frunk_derives contains the custom derivations for certain traits in Frunk."
 license = "MIT"
-documentation = "https://docs.rs/frunk_derives/0.0.10/frunk_derives/"
+documentation = "https://docs.rs/frunk_derives"
 repository = "https://github.com/lloydmeta/frunk"
 keywords = [ "HList", "Generic", "derives"]
 

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -6,7 +6,7 @@ description = "frunk_derives contains the custom derivations for certain traits 
 license = "MIT"
 documentation = "https://docs.rs/frunk_derives"
 repository = "https://github.com/lloydmeta/frunk"
-keywords = [ "HList", "Generic", "derives"]
+keywords = ["Frunk", "derives"]
 
 [badges]
 travis-ci = { repository = "lloydmeta/frunk" }

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -4,8 +4,12 @@ version = "0.0.10"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "frunk_derives contains the custom derivations for certain traits in Frunk."
 license = "MIT"
-homepage = "https://github.com/lloydmeta/frunk"
+documentation = "https://docs.rs/frunk_derives/0.0.10/frunk_derives/"
+repository = "https://github.com/lloydmeta/frunk"
 keywords = [ "HList", "Generic", "derives"]
+
+[badges]
+travis-ci = { repository = "lloydmeta/frunk" }
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Added `documentation` key to rendering of documentation for latest published version of each crate. Renamed `homepage` key to `repository`. Added `badges` table and `travis-ci` item.