### PR TITLE
Feature/coproduct take

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,11 +295,12 @@ assert_eq!(get_from_1a, Some(&3));
 // None because co1 does not contain a bool, it contains an i32
 assert_eq!(get_from_1b, None);
 
-// We can fold our Coproduct into a single value by handling all cases
-let folder = hlist![|i| format!("int {}", i),
+// We can fold our Coproduct into a single value by handling all types in it
+assert_eq!(
+    co1.fold(hlist![|i| format!("int {}", i),
                     |f| format!("float {}", f),
-                    |b| (if b { "t" } else { "f" }).to_string()];
-assert_eq!(co1.fold(&folder), "int 3".to_string());
+                    |b| (if b { "t" } else { "f" }).to_string()]), 
+    "int 3".to_string());
 ```
 
 For more information, check out the []docs for Coproduct](https://beachape.com/frunk/frunk/coproduct/index.html) 

--- a/README.md
+++ b/README.md
@@ -279,11 +279,11 @@ to take a look at `Coproduct`. In Rust, thanks to `enum`, you could potentially 
 want a sum type to do this, but there is a light-weight way of doing it through Frunk:
 
 ```rust
-#[macro_use] extern crate frunk; // for the Coproduct! type macro
+#[macro_use] extern crate frunk; // for the Coprod! type macro
 use frunk::coproduct::*;
 
 // Declare the types we want in our Coproduct
-type I32Bool = Coproduct!(i32, f32, bool);
+type I32Bool = Coprod!(i32, f32, bool);
 
 let co1: I32Bool = into_coproduct(3);
 let get_from_1a: Option<&i32> = co1.get();

--- a/benches/labelled.rs
+++ b/benches/labelled.rs
@@ -56,7 +56,7 @@ struct BigStruct24Fields {
     u: i8,
     v: i32,
     w: f64,
-    x: usize
+    x: usize,
 }
 
 #[derive(LabelledGeneric)]
@@ -85,7 +85,7 @@ struct BigStruct25Fields {
     v: i32,
     w: f64,
     x: usize,
-    y: String
+    y: String,
 }
 
 #[derive(LabelledGeneric)]
@@ -203,7 +203,7 @@ impl From<BigStruct25Fields> for BigStruct25FieldsReverse {
             v: b.v,
             w: b.w,
             x: b.x,
-            y: b.y
+            y: b.y,
         }
     }
 }
@@ -270,33 +270,33 @@ fn build_big_struct_25fields() -> BigStruct25Fields {
 #[bench]
 fn labelled_conversion(b: &mut Bencher) {
     b.iter(|| {
-        let n_u = NewUser {
-            first_name: "Joe",
-            last_name: "Schmoe",
-            age: 30,
-        };
-        <SavedUser as LabelledGeneric>::convert_from(n_u)
-    })
+               let n_u = NewUser {
+                   first_name: "Joe",
+                   last_name: "Schmoe",
+                   age: 30,
+               };
+               <SavedUser as LabelledGeneric>::convert_from(n_u)
+           })
 }
 
 #[bench]
 fn sculpted_conversion(b: &mut Bencher) {
     b.iter(|| {
-        let n_u = NewUser {
-            first_name: "Joe",
-            last_name: "Schmoe",
-            age: 30,
-        };
-        JumbledUser::transform_from(n_u)
-    })
+               let n_u = NewUser {
+                   first_name: "Joe",
+                   last_name: "Schmoe",
+                   age: 30,
+               };
+               JumbledUser::transform_from(n_u)
+           })
 }
 
 #[bench]
 fn big_transform_from_24fields(b: &mut Bencher) {
     b.iter(|| {
-        let j = BigStruct24FieldsReverse::transform_from(build_big_struct_24fields());
-        j
-    })
+               let j = BigStruct24FieldsReverse::transform_from(build_big_struct_24fields());
+               j
+           })
 }
 
 #[bench]

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -20,11 +20,9 @@
 //! // foldr (foldl also available)
 //! let h2 = hlist![1, false, 42f32];
 //! let folded = h2.foldr(
-//!             hlist![
-//!                 |i, acc| i + acc,
-//!                 |_, acc| if acc > 42f32 { 9000 } else { 0 },
-//!                 |f, acc| f + acc
-//!             ],
+//!             hlist![|i, acc| i + acc,
+//!                    |_, acc| if acc > 42f32 { 9000 } else { 0 },
+//!                    |f, acc| f + acc],
 //!             1f32
 //!     );
 //! assert_eq!(folded, 9001);
@@ -32,10 +30,9 @@
 //! let h3 = hlist![9000, "joe", 41f32];
 //! // Mapping over an HList (we use as_ref() to map over the HList without consuming it,
 //! // but you can use the value-consuming version by leaving it off.)
-//! let mapped = h3.as_ref().map(hlist![
-//!                               |&n| n + 1,
-//!                               |&s| s,
-//!                               |&f| f + 1f32]);
+//! let mapped = h3.as_ref().map(hlist![|&n| n + 1,
+//!                                     |&s| s,
+//!                                     |&f| f + 1f32]);
 //! assert_eq!(mapped, hlist![9001, "joe", 42f32]);
 //!
 //! // Plucking a value out by type

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -198,7 +198,7 @@ macro_rules! hlist {
 
     // Just a single item
     ($single: expr) => {
-        $crate::hlist::HCons { head: $single, tail: HNil }
+        $crate::hlist::HCons { head: $single, tail: $crate::hlist::HNil }
     };
 
     ($first: expr, $( $repeated: expr ), +) => {
@@ -263,7 +263,7 @@ macro_rules! Hlist {
 
     // Just a single item
     ($single: ty) => {
-        $crate::hlist::HCons<$single, HNil>
+        $crate::hlist::HCons<$single, $crate::hlist::HNil>
     };
 
     ($first: ty, $( $repeated: ty ), +) => {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,21 +25,18 @@
 //! // foldr (foldl also available)
 //! let h2 = hlist![1, false, 42f32];
 //! let folded = h2.foldr(
-//!             hlist![
-//!                 |i, acc| i + acc,
-//!                 |_, acc| if acc > 42f32 { 9000 } else { 0 },
-//!                 |f, acc| f + acc
-//!             ],
+//!             hlist![|i, acc| i + acc,
+//!                    |_, acc| if acc > 42f32 { 9000 } else { 0 },
+//!                    |f, acc| f + acc],
 //!             1f32
 //!     );
 //! assert_eq!(folded, 9001);
 //!
 //! // Mapping over an HList
 //! let h3 = hlist![9000, "joe", 41f32];
-//! let mapped = h3.map(hlist![
-//!                         |n| n + 1,
-//!                         |s| s,
-//!                         |f| f + 1f32]);
+//! let mapped = (&h3).map(hlist![|&n| n + 1,
+//!                               |&s| s,
+//!                               |&f| f + 1f32]);
 //! assert_eq!(mapped, hlist![9001, "joe", 42f32]);
 //!
 //! // Plucking a value out by type

--- a/src/coproduct.rs
+++ b/src/coproduct.rs
@@ -18,6 +18,10 @@
 //! let get_from_2b: Option<&bool> = co2.get();
 //! assert_eq!(get_from_2a, None);
 //! assert_eq!(get_from_2b, Some(&true));
+//!
+//! // *Taking* stuff (by value)
+//! let take_from_1a: Option<i32> = co1.take();
+//! assert_eq!(take_from_1a, Some(3));
 //! # }
 //! ```
 //!
@@ -32,16 +36,12 @@
 //! # let co1: I32Bool = into_coproduct(3);
 //! # let co2: I32Bool = into_coproduct(true);
 //! assert_eq!(
-//!     co1.as_ref().fold(hlist![
-//!                         |&i| format!("i32 {}", i),
-//!                         |&b| String::from(if b { "t" } else { "f" })
-//!                             ]),
+//!     co1.as_ref().fold(hlist![|&i| format!("i32 {}", i),
+//!                              |&b| String::from(if b { "t" } else { "f" })]),
 //!     "i32 3".to_string());
 //! assert_eq!(
-//!     co2.as_ref().fold(hlist![
-//!                         |&i| format!("i32 {}", i),
-//!                         |&b| String::from(if b { "t" } else { "f" })
-//!                             ]),
+//!     co2.as_ref().fold(hlist![|&i| format!("i32 {}", i),
+//!                              |&b| String::from(if b { "t" } else { "f" })]),
 //!     "t".to_string());
 //!
 //! // There is also a value consuming-variant of fold

--- a/src/coproduct.rs
+++ b/src/coproduct.rs
@@ -4,7 +4,7 @@
 //!
 //! ```
 //! # #[macro_use] extern crate frunk; use frunk::coproduct::*; fn main() {
-//! type I32Bool = Coproduct!(i32, bool);
+//! type I32Bool = Coprod!(i32, bool);
 //! let co1: I32Bool = into_coproduct(3);
 //! let co2: I32Bool = into_coproduct(true);
 //!
@@ -32,7 +32,7 @@
 //! # #[macro_use] extern crate frunk_core;
 //! # use frunk::hlist::*;
 //! # use frunk::coproduct::*; fn main() {
-//! # type I32Bool = Coproduct!(i32, bool);
+//! # type I32Bool = Coprod!(i32, bool);
 //! # let co1: I32Bool = into_coproduct(3);
 //! # let co2: I32Bool = into_coproduct(true);
 //!
@@ -61,14 +61,14 @@ use frunk_core::hlist::*;
 /// Enum type representing a Coproduct. Think of this as a Result, but capable
 /// of supporting any arbitrary number of types instead of just 2.
 ///
-/// To consctruct a Coproduct, you would typically declare a type using the `Coproduct!` type
+/// To consctruct a Coproduct, you would typically declare a type using the `Coprod!` type
 /// macro and then use the `into_coproduct` method.
 ///
 /// # Examples
 ///
 /// ```
 /// # #[macro_use] extern crate frunk; use frunk::coproduct::*; fn main() {
-/// type I32Bool = Coproduct!(i32, bool);
+/// type I32Bool = Coprod!(i32, bool);
 /// let co1: I32Bool = into_coproduct(3);
 /// let get_from_1a: Option<&i32> = co1.get();
 /// let get_from_1b: Option<&bool> = co1.get();
@@ -99,31 +99,31 @@ pub enum CNil {}
 ///
 /// ```
 /// # #[macro_use] extern crate frunk; use frunk::coproduct::*; fn main() {
-/// type I32Bool = Coproduct!(i32, bool);
+/// type I32Bool = Coprod!(i32, bool);
 /// let co1: I32Bool = into_coproduct(3);
 /// # }
 /// ```
 #[macro_export]
-macro_rules! Coproduct {
+macro_rules! Coprod {
     // Nothing
     () => { $crate::coproduct::CNil };
 
     // Just a single item
     ($single: ty) => {
-        $crate::coproduct::Coproduct<$single, CNil>
+        $crate::coproduct::Coproduct<$single, $crate::coproduct::CNil>
     };
 
     ($first: ty, $( $repeated: ty ), +) => {
-        $crate::coproduct::Coproduct<$first, Coproduct!($($repeated), *)>
+        $crate::coproduct::Coproduct<$first, Coprod!($($repeated), *)>
     };
 
     // <-- Forward trailing comma variants
     ($single: ty,) => {
-        Coproduct![$single]
+        Coprod![$single]
     };
 
     ($first: ty, $( $repeated: ty, ) +) => {
-        Coproduct![$first, $($repeated),*]
+        Coprod![$first, $($repeated),*]
     };
     // Forward trailing comma variants -->
 }
@@ -154,7 +154,7 @@ impl<Head, I, Tail, TailIndex> IntoCoproduct<I, There<TailIndex>> for Coproduct<
 ///
 /// ```
 /// # #[macro_use] extern crate frunk; use frunk::coproduct::*; fn main() {
-/// type I32Bool = Coproduct!(i32, f32);
+/// type I32Bool = Coprod!(i32, f32);
 /// let co1: I32Bool = into_coproduct(42f32);
 /// let get_from_1a: Option<&i32> = co1.get();
 /// let get_from_1b: Option<&f32> = co1.get();
@@ -177,7 +177,7 @@ pub fn into_coproduct<C, I, Index>(to_into: I) -> C
 ///
 /// ```
 /// # #[macro_use] extern crate frunk; use frunk::coproduct::*; fn main() {
-/// type I32Bool = Coproduct!(i32, f32);
+/// type I32Bool = Coprod!(i32, f32);
 /// let co1: I32Bool = into_coproduct(42f32);
 /// let get_from_1a: Option<&i32> = co1.get();
 /// let get_from_1b: Option<&f32> = co1.get();
@@ -220,7 +220,7 @@ impl<Head, FromTail, Tail, TailIndex> CoproductSelector<FromTail, There<TailInde
 ///
 /// ```
 /// # #[macro_use] extern crate frunk; use frunk::coproduct::*; fn main() {
-/// type I32Bool = Coproduct!(i32, f32);
+/// type I32Bool = Coprod!(i32, f32);
 /// let co1: I32Bool = into_coproduct(42f32);
 /// let get_from_1a: Option<i32> = co1.take();
 /// let get_from_1b: Option<f32> = co1.take();
@@ -266,7 +266,7 @@ impl<Head, FromTail, Tail, TailIndex> CoproductTaker<FromTail, There<TailIndex>>
 /// # #[macro_use] extern crate frunk;
 /// # use frunk::coproduct::*;
 /// # use frunk::hlist::*; fn main() {
-/// type I32StrBool = Coproduct!(i32, f32, bool);
+/// type I32StrBool = Coprod!(i32, f32, bool);
 ///
 /// let co1: I32StrBool = into_coproduct(3);
 /// let co2: I32StrBool = into_coproduct(true);
@@ -342,7 +342,7 @@ mod tests {
 
     #[test]
     fn test_into_coproduct() {
-        type I32StrBool = Coproduct!(i32, &'static str, bool);
+        type I32StrBool = Coprod!(i32, &'static str, bool);
 
         let co1: I32StrBool = into_coproduct(3);
         assert_eq!(co1, Inl(3));
@@ -362,7 +362,7 @@ mod tests {
 
     #[test]
     fn test_coproduct_fold_consuming() {
-        type I32StrBool = Coproduct!(i32, f32, bool);
+        type I32StrBool = Coprod!(i32, f32, bool);
 
         let co1: I32StrBool = into_coproduct(3);
         let folded = co1.fold(hlist![|i| format!("int {}", i),
@@ -374,7 +374,7 @@ mod tests {
 
     #[test]
     fn test_coproduct_fold_non_consuming() {
-        type I32StrBool = Coproduct!(i32, f32, bool);
+        type I32StrBool = Coprod!(i32, f32, bool);
 
         let co1: I32StrBool = into_coproduct(3);
         let co2: I32StrBool = into_coproduct(true);

--- a/src/coproduct.rs
+++ b/src/coproduct.rs
@@ -198,7 +198,7 @@ impl<Head, Tail> CoproductSelector<Head, Here> for Coproduct<Head, Tail> {
 }
 
 impl<Head, FromTail, Tail, TailIndex> CoproductSelector<FromTail, There<TailIndex>>
-for Coproduct<Head, Tail>
+    for Coproduct<Head, Tail>
     where Tail: CoproductSelector<FromTail, TailIndex>
 {
     fn get(&self) -> Option<&FromTail> {
@@ -241,7 +241,7 @@ impl<Head, Tail> CoproductTaker<Head, Here> for Coproduct<Head, Tail> {
 }
 
 impl<Head, FromTail, Tail, TailIndex> CoproductTaker<FromTail, There<TailIndex>>
-for Coproduct<Head, Tail>
+    for Coproduct<Head, Tail>
     where Tail: CoproductTaker<FromTail, TailIndex>
 {
     fn take(self) -> Option<FromTail> {
@@ -364,8 +364,8 @@ mod tests {
 
         let co1: I32StrBool = into_coproduct(3);
         let folded = co1.fold(hlist![|i| format!("int {}", i),
-                                      |f| format!("float {}", f),
-                                      |b| (if b { "t" } else { "f" }).to_string()]);
+                                     |f| format!("float {}", f),
+                                     |b| (if b { "t" } else { "f" }).to_string()]);
 
         assert_eq!(folded, "int 3".to_string());
     }
@@ -378,24 +378,20 @@ mod tests {
         let co2: I32StrBool = into_coproduct(true);
         let co3: I32StrBool = into_coproduct(42f32);
 
-        assert_eq!(
-            co1.as_ref().fold(hlist![
-                            |&i| format!("int {}", i),
-                            |&f| format!("float {}", f),
-                            |&b| (if b { "t" } else { "f" }).to_string()]
-            )
-            , "int 3".to_string());
-        assert_eq!(
-            co2.as_ref().fold(hlist![
-                            |&i| format!("int {}", i),
-                            |&f| format!("float {}", f),
-                            |&b| (if b { "t" } else { "f" }).to_string()]),
-            "t".to_string());
-        assert_eq!(
-            co3.as_ref().fold(hlist![
-                            |&i| format!("int {}", i),
-                            |&f| format!("float {}", f),
-                            |&b| (if b { "t" } else { "f" }).to_string()]),
-            "float 42".to_string());
+        assert_eq!(co1.as_ref()
+                       .fold(hlist![|&i| format!("int {}", i),
+                                    |&f| format!("float {}", f),
+                                    |&b| (if b { "t" } else { "f" }).to_string()]),
+                   "int 3".to_string());
+        assert_eq!(co2.as_ref()
+                       .fold(hlist![|&i| format!("int {}", i),
+                                    |&f| format!("float {}", f),
+                                    |&b| (if b { "t" } else { "f" }).to_string()]),
+                   "t".to_string());
+        assert_eq!(co3.as_ref()
+                       .fold(hlist![|&i| format!("int {}", i),
+                                    |&f| format!("float {}", f),
+                                    |&b| (if b { "t" } else { "f" }).to_string()]),
+                   "float 42".to_string());
     }
 }

--- a/src/coproduct.rs
+++ b/src/coproduct.rs
@@ -35,21 +35,23 @@
 //! # type I32Bool = Coproduct!(i32, bool);
 //! # let co1: I32Bool = into_coproduct(3);
 //! # let co2: I32Bool = into_coproduct(true);
+//!
+//! // In the below, we use unimplemented!() to make it obvious hat we know what type of
+//! // item is inside our coproducts co1 and co2 but in real life, you should be writing
+//! // complete functions for all the cases when folding coproducts
 //! assert_eq!(
 //!     co1.as_ref().fold(hlist![|&i| format!("i32 {}", i),
-//!                              |&b| String::from(if b { "t" } else { "f" })]),
+//!                              |&b| unimplemented!() /* we know this won't happen for co1 */ ]),
 //!     "i32 3".to_string());
 //! assert_eq!(
-//!     co2.as_ref().fold(hlist![|&i| format!("i32 {}", i),
+//!     co2.as_ref().fold(hlist![|&i| unimplemented!() /* we know this won't happen for co2 */,
 //!                              |&b| String::from(if b { "t" } else { "f" })]),
 //!     "t".to_string());
 //!
 //! // There is also a value consuming-variant of fold
 //!
-//! let folded = co1.fold(hlist![
-//!   |i| format!("i32 {}", i),
-//!   |b| String::from(if b { "t" } else { "f" })
-//! ]);
+//! let folded = co1.fold(hlist![|i| format!("i32 {}", i),
+//!                              |b| String::from(if b { "t" } else { "f" })]);
 //! assert_eq!(folded, "i32 3".to_string());
 //! # }
 //! ```

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -85,7 +85,8 @@ pub fn combine_n<T>(o: &T, times: u32) -> T
 pub fn combine_all<T>(xs: &Vec<T>) -> T
     where T: Monoid + Semigroup + Clone
 {
-    xs.iter().fold(<T as Monoid>::empty(), |acc, next| acc.combine(&next))
+    xs.iter()
+        .fold(<T as Monoid>::empty(), |acc, next| acc.combine(&next))
 }
 
 impl<T> Monoid for Option<T>

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -72,7 +72,9 @@ pub trait Semigroup {
 /// if all of the sub-element types are also Semiups
 impl<H: Semigroup, T: HList + Semigroup> Semigroup for HCons<H, T> {
     fn combine(&self, other: &Self) -> Self {
-        self.tail.combine(&other.tail).prepend(self.head.combine(&other.head))
+        self.tail
+            .combine(&other.tail)
+            .prepend(self.head.combine(&other.head))
     }
 }
 

--- a/src/validated.rs
+++ b/src/validated.rs
@@ -317,13 +317,14 @@ mod tests {
     fn test_to_result_ok() {
         let v = get_name(YahNah::Yah).into_validated() + get_age(YahNah::Yah) +
                 get_email(YahNah::Yah);
-        let person = v.into_result().map(|hlist_pat!(name, age, email)| {
-            Person {
-                name: name,
-                age: age,
-                email: email,
-            }
-        });
+        let person = v.into_result()
+            .map(|hlist_pat!(name, age, email)| {
+                     Person {
+                         name: name,
+                         age: age,
+                         email: email,
+                     }
+                 });
 
         assert_eq!(person.unwrap(),
                    Person {

--- a/src/validated.rs
+++ b/src/validated.rs
@@ -44,7 +44,7 @@
 //! # }
 //! ```
 
-use frunk_core::hlist::*;
+use super::hlist::*;
 use std::ops::Add;
 
 /// A Validated is either an Ok holding an HList or an Err, holding a vector
@@ -239,7 +239,6 @@ impl<T, E, T2> Add<Validated<T2, E>> for Validated<T, E>
 
 #[cfg(test)]
 mod tests {
-    use frunk_core::hlist::*;
     use super::*;
 
     #[test]

--- a/tests/coproduct_tests.rs
+++ b/tests/coproduct_tests.rs
@@ -1,0 +1,41 @@
+#[macro_use]
+extern crate frunk;
+#[macro_use]
+extern crate frunk_core; // for hlist macro
+use frunk::coproduct::*;
+
+#[test]
+fn test_into_coproduct() {
+    type I32StrBool = Coprod!(i32, &'static str, bool);
+
+    let co1: I32StrBool = into_coproduct(3);
+    let get_from_1a: Option<&i32> = co1.get();
+    let get_from_1b: Option<&bool> = co1.get();
+    assert_eq!(get_from_1a, Some(&3));
+    assert_eq!(get_from_1b, None);
+}
+
+#[test]
+fn test_coproduct_fold_consuming() {
+    type I32StrBool = Coprod!(i32, f32, bool);
+
+    let co1: I32StrBool = into_coproduct(3);
+    let folded = co1.fold(hlist![|i| format!("int {}", i),
+                                 |f| format!("float {}", f),
+                                 |b| (if b { "t" } else { "f" }).to_string()]);
+
+    assert_eq!(folded, "int 3".to_string());
+}
+
+#[test]
+fn test_coproduct_fold_non_consuming() {
+    type I32StrBool = Coprod!(i32, f32, bool);
+
+    let co: I32StrBool = into_coproduct(true);;
+
+    assert_eq!(co.as_ref()
+                   .fold(hlist![|&i| format!("int {}", i),
+                                |&f| format!("float {}", f),
+                                |&b| (if b { "t" } else { "f" }).to_string()]),
+               "t".to_string());
+}

--- a/tests/generic_tests.rs
+++ b/tests/generic_tests.rs
@@ -2,7 +2,6 @@ extern crate frunk;
 #[macro_use] // for the hlist macro
 extern crate frunk_core;
 
-use frunk::hlist::*;
 use frunk::generic::*;
 
 mod common;


### PR DESCRIPTION
- Rename Coproduct! type macro to Coprod!
- Make coproduct folding take an hlist of functions by value so we can ease the restraint to FnOnce from Fn
- Fix unnamespaced references to CNil and HNil in macros