### PR TITLE
Inline Sculpting to make transforming zero-cost, always

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 rust:
   - stable
-  - nightly
+  - nightly-2017-04-21
 
 cache: cargo
 

--- a/benches/labelled.rs
+++ b/benches/labelled.rs
@@ -309,21 +309,21 @@ fn big_from_24fields(b: &mut Bencher) {
 
 // Hilariously, uncommenting this out will kill the performance in the above 2 benchmarks
 
-//#[bench]
-//fn big_transform_from_25fields(b: &mut Bencher) {
-//    b.iter(|| {
-//        let j = BigStruct25FieldsReverse::transform_from(build_big_struct_25fields());
-//        j
-//    })
-//}
-//
-//#[bench]
-//fn big_from_25fields(b: &mut Bencher) {
-//    b.iter(|| {
-//        let j = <BigStruct25FieldsReverse as From<BigStruct25Fields>>::from(build_big_struct_25fields());
-//        j
-//    })
-//}
+#[bench]
+fn big_transform_from_25fields(b: &mut Bencher) {
+    b.iter(|| {
+        let j = BigStruct25FieldsReverse::transform_from(build_big_struct_25fields());
+        j
+    })
+}
+
+#[bench]
+fn big_from_25fields(b: &mut Bencher) {
+    b.iter(|| {
+        let j = <BigStruct25FieldsReverse as From<BigStruct25Fields>>::from(build_big_struct_25fields());
+        j
+    })
+}
 
 
 

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -435,6 +435,7 @@ pub trait Sculptor<Target, Indices> {
 impl<Source> Sculptor<HNil, HNil> for Source {
     type Remainder = Source;
 
+    #[inline(always)]
     fn sculpt(self) -> (HNil, Self::Remainder) {
         (HNil, self)
     }
@@ -453,6 +454,7 @@ for HCons<SHead, STail>
 {
     type Remainder = <<HCons<SHead, STail> as Plucker<THead, IndexHead>>::Remainder as Sculptor<TTail, IndexTail>>::Remainder;
 
+    #[inline(always)]
     fn sculpt(self) -> (HCons<THead, TTail>, Self::Remainder) {
         let (p, r): (THead, <HCons<SHead, STail> as Plucker<THead, IndexHead>>::Remainder) =
             self.pluck();


### PR DESCRIPTION
Add inline always to sculpt to make it LabelledGeneric::transform_from a zero-cost extraction