### PR TITLE
derive Hash

### DIFF
--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -101,7 +101,7 @@ pub trait HList: Sized {
 /// let h = h.head;
 /// assert_eq!(h, 1);
 /// ```
-#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
+#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub struct HNil;
 
 impl HList for HNil {
@@ -116,7 +116,7 @@ impl AsRef<HNil> for HNil {
 
 /// Represents the most basic non-empty HList. Its value is held in `head`
 /// while its tail is another HList.
-#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
+#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub struct HCons<H, T> {
     pub head: H,
     pub tail: T,

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -216,7 +216,7 @@ macro_rules! create_enums_for {
     ($($i: ident)*) => {
         $(
             #[allow(non_snake_case, non_camel_case_types)]
-            #[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
+            #[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
             pub enum $i {}
         )*
     }
@@ -242,7 +242,7 @@ create_enums_for! { a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D 
 /// assert_eq!(labelled.value, "joe")
 /// # }
 /// ```
-#[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
+#[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub struct Field<Name, Type> {
     name_type_holder: PhantomData<Name>,
     pub name: &'static str,

--- a/laws/src/wrapper.rs
+++ b/laws/src/wrapper.rs
@@ -10,7 +10,7 @@ use quickcheck::*;
 /// that we don't own for type we don't own.
 ///
 /// Avoids the orphan typeclass instances problem in Haskell.
-#[derive(Eq, PartialEq, PartialOrd, Debug, Clone)]
+#[derive(Eq, PartialEq, PartialOrd, Debug, Clone, Hash)]
 pub struct Wrapper<A>(A);
 
 impl<A: Arbitrary + Ord + Clone> Arbitrary for Wrapper<Max<A>> {

--- a/src/coproduct.rs
+++ b/src/coproduct.rs
@@ -78,7 +78,7 @@ use frunk_core::hlist::*;
 /// assert_eq!(get_from_1b, None);
 /// # }
 /// ```
-#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
+#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub enum Coproduct<H, T> {
     /// Coproduct is either H or T, in this case, it is H
     Inl(H),
@@ -89,7 +89,7 @@ pub enum Coproduct<H, T> {
 /// Phantom type for signature purposes only (has no value)
 ///
 /// Used by the macro to terminate the Coproduct type signature
-#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
+#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub enum CNil {}
 
 /// Returns a type signature for a Coproduct of the provided types

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -36,23 +36,23 @@ use std::collections::hash_map::Entry;
 use frunk_core::hlist::*;
 
 /// Wrapper type for types that are ordered and can have a Max combination
-#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
+#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub struct Max<T: Ord>(pub T);
 
 /// Wrapper type for types that are ordered and can have a Min combination
-#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
+#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub struct Min<T: Ord>(pub T);
 
 /// Wrapper type for types that can have a Product combination
-#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
+#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub struct Product<T>(pub T);
 
 /// Wrapper type for boolean that acts as a bitwise && combination
-#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
+#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub struct All<T>(pub T);
 
 /// Wrapper type for boolean that acts as a bitwise || combination
-#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord)]
+#[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub struct Any<T>(pub T);
 
 /// A Semigroup is a class of thing that has a definable combine operation

--- a/src/validated.rs
+++ b/src/validated.rs
@@ -49,7 +49,7 @@ use std::ops::Add;
 
 /// A Validated is either an Ok holding an HList or an Err, holding a vector
 /// of collected errors.
-#[derive(PartialEq, Debug, Eq, Clone, PartialOrd, Ord)]
+#[derive(PartialEq, Debug, Eq, Clone, PartialOrd, Ord, Hash)]
 pub enum Validated<T, E>
     where T: HList
 {


### PR DESCRIPTION
Added `#[derive(Hash)]` to all types that are deriving anyway.

Closes #55 