### PR TITLE
Adds LiftFrom + LiftInto traits, Generic & From/Into for flat tuples <-> HList

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ Cargo.lock
 *.iml
 benches-control
 benches-variable
+
+# VSCode:
+
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk"
-version = "0.1.33"
+version = "0.1.34"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk provides developers with a number of functional programming tools like HList, Coproduct, Generic, LabelledGeneric, Validated, Monoid, Semigroup and friends."
 license = "MIT"
@@ -17,15 +17,15 @@ time = "0.1.36"
 
 [dependencies.frunk_core]
 path = "core"
-version = "0.0.20"
+version = "0.0.21"
 
 [dependencies.frunk_derives]
 path = "derives"
-version = "0.0.21"
+version = "0.0.22"
 
 [dev-dependencies.frunk_laws]
 path = "laws"
-version = "0.0.11"
+version = "0.0.12"
 
 [dependencies]
 serde = { version = "^1.0", optional = true, default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_core"
-version = "0.0.20"
+version = "0.0.21"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk core provides developers with HList and Generic"
 license = "MIT"
@@ -20,4 +20,4 @@ with-serde = ["serde", "serde_derive"]
 
 [dev-dependencies.frunk_derives]
 path = "../derives"
-version = "0.0.21"
+version = "0.0.22"

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -1416,7 +1416,7 @@ mod tests {
     }
 
     #[test]
-    fn test_partial() {
+    fn test_lift() {
         type H = Hlist![(), usize, f64, (), bool];
 
         // Ensure type inference works as expected first:

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -358,7 +358,7 @@ where
 ///
 /// Users should normally allow type inference to create this type
 #[allow(dead_code)]
-pub enum Here {}
+pub struct Here;
 
 /// Used as an index into an `HList`.
 ///
@@ -1082,6 +1082,82 @@ impl<T> Into<Vec<T>> for HNil {
     }
 }
 
+impl Default for HNil {
+    fn default() -> Self { HNil }
+}
+
+impl<T: Default, Tail: Default + HList> Default for HCons<T, Tail> {
+    fn default() -> Self {
+        h_cons(T::default(), Tail::default())
+    }
+}
+
+/// Indexed type conversions of `T -> Self` with index `I`.
+/// This is a generalized version of `From` which for example allows the caller
+/// to use default values for parts of `Self` and thus "fill in the blanks".
+///
+/// `LiftFrom` is the reciprocal of `LiftInto`.
+pub trait LiftFrom<T, I> {
+    /// Performs the indexed conversion.
+    fn lift_from(part: T) -> Self;
+}
+
+/// Free function version of `LiftFrom::lift_from`.
+pub fn lift_from<I, T, PF: LiftFrom<T, I>>(part: T) -> PF {
+    PF::lift_from(part)
+}
+
+/// An indexed conversion that consumes `self`, and produces a `T`. To produce
+/// `T`, the index `I` may be used to for example "fill in the blanks".
+/// `LiftInto` is the reciprocal of `LiftFrom`.
+pub trait LiftInto<T, I> {
+    /// Performs the indexed conversion.
+    fn lift_into(self) -> T;
+}
+
+impl<T, U, I> LiftInto<U, I> for T
+where
+    U: LiftFrom<T, I>
+{
+    fn lift_into(self) -> U {
+        LiftFrom::lift_from(self)
+    }
+}
+
+impl<T, Tail> LiftFrom<T, Here> for HCons<T, Tail>
+where
+    Tail: Default + HList
+{
+    fn lift_from(part: T) -> Self {
+        h_cons(part.into(), Tail::default())
+    }
+}
+
+impl<Head, Tail, ValAtIx, TailIx> LiftFrom<ValAtIx, There<TailIx>>
+for HCons<Head, Tail>
+where
+    Head: Default,
+    Tail: HList + LiftFrom<ValAtIx, TailIx>,
+{
+    fn lift_from(part: ValAtIx) -> Self {
+        h_cons(Head::default(), Tail::lift_from(part))
+    }
+}
+
+/// An index denoting that `Suffix` is just that.
+struct Suffixed<Suffix>(PhantomData<Suffix>);
+
+impl<Prefix, Suffix> LiftFrom<Prefix, Suffixed<Suffix>>
+for <Prefix as Add<Suffix>>::Output
+where
+    Prefix: HList + Add<Suffix>,
+    Suffix: Default,
+{
+    fn lift_from(part: Prefix) -> Self {
+        part + Suffix::default()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1337,5 +1413,33 @@ mod tests {
         let h = hlist![1, 2, 3, 4, 5];
         let as_vec: Vec<_> = h.into();
         assert_eq!(as_vec, vec![1, 2, 3, 4, 5])
+    }
+
+    #[test]
+    fn test_partial() {
+        type H = Hlist![(), usize, f64, (), bool];
+
+        // Ensure type inference works as expected first:
+        let x: H = 1337.lift_into();
+        assert_eq!(x, hlist![(), 1337, 0.0, (), false]);
+
+        let x = H::lift_from(42.0);
+        assert_eq!(x, hlist![(), 0, 42.0, (), false]);
+
+        let x: H = lift_from(true);
+        assert_eq!(x, hlist![(), 0, 0.0, (), true]);
+
+        // Sublists:
+        let x: H = hlist![(), true].lift_into();
+        assert_eq!(x, hlist![(), 0, 0.0, (), true]);
+
+        let x: H = hlist![3.0, ()].lift_into();
+        assert_eq!(x, hlist![(), 0, 3.0, (), false]);
+
+        let x: H = hlist![(), 1337].lift_into();
+        assert_eq!(x, hlist![(), 1337, 0.0, (), false]);
+
+        let x: H = hlist![(), 1337, 42.0, (), true].lift_into();
+        assert_eq!(x, hlist![(), 1337, 42.0, (), true]);
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -61,6 +61,7 @@
 pub mod hlist;
 pub mod generic;
 pub mod labelled;
+mod tuples;
 
 #[cfg(feature = "with_serde")]
 #[macro_use]

--- a/core/src/tuples.rs
+++ b/core/src/tuples.rs
@@ -80,12 +80,12 @@ macro_rules! tup_iso {
 
 impl Generic for () {
     type Repr = Hlist![];
-    fn into(self) -> Self::Repr { Self::Repr }
+    fn into(self) -> Self::Repr { hlist![] }
     fn from(_: Self::Repr) -> Self { () }
 }
 
 impl From<()> for Hlist![] {
-    fn from(_: ()) -> Self { Generic::from(()) }
+    fn from(_: ()) -> Self { hlist![] }
 }
 
 tup_def!( T0 ; F1, ; T1, );

--- a/core/src/tuples.rs
+++ b/core/src/tuples.rs
@@ -1,0 +1,109 @@
+//! This module is held separate to put generated variadic generics for tuples
+//! at the end of the documentation so as to not disturb the reader when reading
+//! documentation.
+
+use generic::Generic;
+
+macro_rules! tup_def {
+    ( $($dtype: ident),* ; ; ) => {};
+    ( $($dtype: ident),* ;
+      $fone: ident $(, $ftype: ident)*, ;
+      $sone: ident $(, $stype: ident)*,
+    ) => {
+        tup_def!( $($dtype,)* $sone ; $($ftype,)* ; $($stype,)* );
+
+        impl< $($dtype: Default,)*
+                $fone , $sone:  From<$fone> ,
+              $($ftype, $stype: From<$ftype>,)*
+        > From< ( $fone, $( $ftype, )* ) >
+        for Hlist![$( $dtype, )* $sone, $( $stype, )* ] {
+            fn from(f: ( $fone, $( $ftype, )* )) -> Self {
+                #[allow(non_snake_case)]
+                let ( $fone, $( $ftype, )* ) = f;
+                hlist![$($dtype::default(),)* $fone.into(), $($ftype.into(),)*]
+            }
+        }
+    };
+}
+
+macro_rules! tup_iso {
+    ( $t: ident ) => {
+        impl<$t> Generic for ($t,) {
+            type Repr = Hlist![$t];
+            fn into(self) -> Self::Repr { hlist![self.0] }
+            fn from(r: Self::Repr) -> Self { (r.head,) }
+        }
+
+        impl<$t> From<($t,)> for Hlist![$t] {
+            fn from(tup: ($t,)) -> Self { Generic::into(tup) }
+        }
+
+        impl<$t> Into<($t,)> for Hlist![$t] {
+            fn into(self) -> ($t,) { Generic::from(self) }
+        }
+    };
+
+    ( $type1: ident, $( $type: ident ),* ) => {
+        tup_iso!($( $type ),*);
+
+        impl<$type1, $($type),*> Generic for ($type1, $($type),*,) {
+            type Repr = Hlist![$type1, $($type),*,];
+
+            fn into(self) -> Self::Repr {
+                #[allow(non_snake_case)]
+                let ($type1, $($type),*,) = self;
+                hlist![$type1, $($type),*,]
+            }
+
+            fn from(r: Self::Repr) -> Self {
+                #[allow(non_snake_case)]
+                let hlist_pat![$type1, $($type),*,] = r;
+                ($type1, $($type),*,)
+            }
+        }
+
+        impl<$type1, $($type),*> From< ( $type1, $($type),*, ) >
+        for Hlist![ $type1, $($type),*, ] {
+            fn from(tup: ( $type1, $( $type ),*, ) ) -> Self {
+                Generic::into(tup)
+            }
+        }
+
+        impl< $type1, $($type),*> Into< ( $type1, $($type),*, ) >
+        for Hlist![ $type1, $($type),*, ] {
+            fn into(self) -> ( $type1, $( $type ),*, ) {
+                Generic::from(self)
+            }
+        }
+    };
+}
+
+impl Generic for () {
+    type Repr = Hlist![];
+    fn into(self) -> Self::Repr { Self::Repr }
+    fn from(_: Self::Repr) -> Self { () }
+}
+
+impl From<()> for Hlist![] {
+    fn from(_: ()) -> Self { Generic::from(()) }
+}
+
+tup_def!( T0 ; F1, ; T1, );
+tup_def!( T0 ; F1, F2, ;
+               T1, T2, );
+tup_def!( T0 ; F1, F2, F3, ;
+               T1, T2, T3, );
+tup_def!( T0 ; F1, F2, F3, F4, ;
+               T1, T2, T3, T4, );
+tup_def!( T0 ; F1, F2, F3, F4, F5, ;
+               T1, T2, T3, T4, T5, );
+tup_def!( T0 ; F1, F2, F3, F4, F5, F6, ;
+               T1, T2, T3, T4, T5, T6, );
+tup_def!( T0 ; F1, F2, F3, F4, F5, F6, F7, ;
+               T1, T2, T3, T4, T5, T6, T7, );
+tup_def!( T0 ; F1, F2, F3, F4, F5, F6, F7, F8, ;
+               T1, T2, T3, T4, T5, T6, T7, T8, );
+tup_def!( T0 ; F1, F2, F3, F4, F5, F6, F7, F8, F9, ;
+               T1, T2, T3, T4, T5, T6, T7, T8, T9, );
+
+tup_iso!(T9, T8, T7, T6, T5, T4, T3, T2, T1, T0);

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_derives"
-version = "0.0.21"
+version = "0.0.22"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "frunk_derives contains the custom derivations for certain traits in Frunk."
 license = "MIT"
@@ -20,4 +20,4 @@ quote = "0.3.15"
 
 [dependencies.frunk_core]
 path = "../core"
-version = "0.0.20"
+version = "0.0.21"

--- a/laws/Cargo.toml
+++ b/laws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_laws"
-version = "0.0.11"
+version = "0.0.12"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "frunk_laws contains laws for algebras declared in Frunk."
 license = "MIT"
@@ -13,7 +13,7 @@ travis-ci = { repository = "lloydmeta/frunk" }
 
 [dependencies.frunk]
 path = ".."
-version = "0.1.33"
+version = "0.1.34"
 
 [dependencies]
 quickcheck = "0.4.1"


### PR DESCRIPTION
+ Bumps version numbers.
+ ignores `.vscode/`
+ `Here` becomes a struct instead - `Here/There` is just a normal type level `Nat` construct now.
+ Adds conversion traits `LiftFrom` and `LiftInto` allowing the users to construct HLists from an element or a sublist while defaulting everything not given.
+  Makes flat tuples up to `(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)` impl `Generic` as well as providing `From` + `Into` impls.