### PR TITLE
Feature/CoproductEmbedder

### DIFF
--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -552,7 +552,7 @@ impl<Choices> CoproductSubsetter<CNil, HNil> for Choices {
     { Err(self) }
 }
 
-/// Trait for upcasting a coproduct into another that can hold its variants.
+/// Trait for converting a coproduct into another that can hold its variants.
 ///
 /// This converts a coproduct into another one which is capable of holding each
 /// of its types. The most well-supported use-cases (i.e. those where type inference


### PR DESCRIPTION
## Itemized changes

From most significant to least:

**Added `CoproductEmbedder`.**

**Documented the rules of type inference for `CoprodInjector`.** I did this because I allude to these rules in the docs for `CoproductEmbedder`. (In the future, I would like to see [similar documentation](https://github.com/lloydmeta/frunk/issues/94) added to all methods.)

**Changed headline of `CoprodInjector` to not use the word "inject."**

**Removed `#[doc(hidden)]` changes from some trait impls for `CNil`.** In my opinion it actually makes the documentation nicer when the reader can see the base cases for recursion.
*(@lloydmeta let me know if you disagree and I can undo this)*

**Add missing code tags to some markdown.**

---

Closes #86.