### PR TITLE
Follow conventional feature-gating for serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,7 @@ path = "laws"
 version = "0.0.14"
 
 [dependencies]
-serde = { version = "^1.0", optional = true, default-features = false }
-serde_derive = { version = "^1.0", optional = true, default-features = false }
-
-[features]
-with-serde = ["serde", "serde_derive"]
+serde = { version = "^1.0", optional = true, features = [ "derive" ] }
 
 [profile.bench]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ For a deep dive, RustDocs are available for:
 4. [Validated](#validated)
 5. [Semigroup](#semigroup)
 6. [Monoid](#monoid)
-7. [Todo](#todo)
-8. [Contributing](#contributing)
-9. [Inspirations](#inspirations)
-10. [Maintainers](#maintainers)
+7. [Features](#features)
+8. [Todo](#todo)
+9. [Contributing](#contributing)
+10. [Inspirations](#inspirations)
+11. [Maintainers](#maintainers)
 
 ## Examples
 
@@ -426,6 +427,26 @@ assert_eq!(combine_all(&tuples), expected)
 
 let product_nums = vec![Product(2), Product(3), Product(4)];
 assert_eq!(combine_all(&product_nums), Product(24))
+```
+
+### Features
+
+Frunk comes with support for deriving [serde](https://github.com/serde-rs/serde) serializer/deserializers for its core 
+data structures. This can be enabled by adding the `serde` feature flag.
+
+For example, if you'd like to use just `frunk-core` with serde
+
+```toml
+[dependencies]
+frunk-core = { version = "$version", features = ["serde"] }
+```
+
+Or, if you'd like to use `frunk` with serde, you need to explicitly include `frunk-core` as well
+
+```toml
+[dependencies]
+frunk = { version = "$version", features = ["serde"] }
+frunk-core = { version = "$version", features = ["serde"] }
 ```
 
 ## Todo

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,11 +12,7 @@ keywords = ["Frunk", "HList", "Generic", "Coproduct", "LabelledGeneric"]
 travis-ci = { repository = "lloydmeta/frunk" }
 
 [dependencies]
-serde = { version = "^1.0", optional = true, default-features = false }
-serde_derive = { version = "^1.0", optional = true, default-features = false }
-
-[features]
-with-serde = ["serde", "serde_derive"]
+serde = { version = "^1.0", optional = true, features = [ "derive" ] }
 
 [dev-dependencies.frunk_derives]
 path = "../derives"

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -89,6 +89,7 @@ use hlist::*;
 /// # }
 /// ```
 #[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Coproduct<H, T> {
     /// Coproduct is either H or T, in this case, it is H
     Inl(H),
@@ -100,6 +101,7 @@ pub enum Coproduct<H, T> {
 ///
 /// Used by the macro to terminate the Coproduct type signature
 #[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CNil {}
 
 /// Returns a type signature for a Coproduct of the provided types

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -134,7 +134,7 @@ pub trait HList: Sized {
 /// assert_eq!(h, 1);
 /// ```
 #[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct HNil;
 
 impl HList for HNil {
@@ -153,7 +153,7 @@ impl AsRef<HNil> for HNil {
 /// Represents the most basic non-empty HList. Its value is held in `head`
 /// while its tail is another HList.
 #[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct HCons<H, T> {
     pub head: H,
     pub tail: T,

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -250,7 +250,7 @@ create_enums_for! { a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D 
 /// assert_eq!(labelled.value, "joe")
 /// # }
 /// ```
-#[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub struct Field<Name, Type> {
     name_type_holder: PhantomData<Name>,
@@ -260,7 +260,7 @@ pub struct Field<Name, Type> {
 
 /// A version of Field that doesn't have a type-level label, just a
 /// value-level one
-#[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub struct ValueField<Type> {
     pub name: &'static str,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -64,6 +64,6 @@ pub mod generic;
 pub mod labelled;
 mod tuples;
 
-#[cfg(feature = "with_serde")]
+#[cfg(feature = "serde")]
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;


### PR DESCRIPTION
Closes #97

* Follow guidelines in https://rust-lang-nursery.github.io/api-guidelines/interoperability.html#data-structures-implement-serdes-serialize-deserialize-c-serde
* Add serde derivation for Coproducts as well