### PR TITLE
Inherent methods for core types

### DIFF
--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -485,7 +485,7 @@ impl<Head, Tail> Coproduct<Head, Tail> {
 /// Coproducts of unknown type. In most code, `Coproduct::inject` will
 /// "just work," with or without this trait.
 ///
-/// [`Coproduct::inject`]: ../enum.Coproduct.html#method.inject
+/// [`Coproduct::inject`]: enum.Coproduct.html#method.inject
 pub trait CoprodInjector<InjectType, Index> {
     /// Instantiate a coproduct from an element.
     ///
@@ -495,7 +495,7 @@ pub trait CoprodInjector<InjectType, Index> {
     /// trait method is the location of the type parameters.
     /// (here, they are on the trait rather than the method)
     ///
-    /// [inherent static method]: ../enum.Coproduct.html#method.inject
+    /// [inherent static method]: enum.Coproduct.html#method.inject
     fn inject(to_insert: InjectType) -> Self;
 }
 
@@ -526,7 +526,7 @@ where
 /// Coproducts of unknown type. If you have a Coproduct of known type,
 /// then `co.get()` should "just work" even without the trait.
 ///
-/// [`Coproduct::get`]: ../enum.Coproduct.html#method.get
+/// [`Coproduct::get`]: enum.Coproduct.html#method.get
 pub trait CoproductSelector<S, I> {
     /// Borrow an element from a coproduct by type.
     ///
@@ -536,7 +536,7 @@ pub trait CoproductSelector<S, I> {
     /// trait method is the location of the type parameters.
     /// (here, they are on the trait rather than the method)
     ///
-    /// [inherent method]: ../enum.Coproduct.html#method.get
+    /// [inherent method]: enum.Coproduct.html#method.get
     fn get(&self) -> Option<&S>;
 }
 
@@ -573,7 +573,7 @@ where
 /// Coproducts of unknown type. If you have a Coproduct of known type,
 /// then `co.take()` should "just work" even without the trait.
 ///
-/// [`Coproduct::take`]: ../enum.Coproduct.html#method.take
+/// [`Coproduct::take`]: enum.Coproduct.html#method.take
 pub trait CoproductTaker<S, I> {
     /// Retrieve an element from a coproduct by type, ignoring all others.
     ///
@@ -583,7 +583,7 @@ pub trait CoproductTaker<S, I> {
     /// trait method is the location of the type parameters.
     /// (here, they are on the trait rather than the method)
     ///
-    /// [inherent method]: ../enum.Coproduct.html#method.take
+    /// [inherent method]: enum.Coproduct.html#method.take
     fn take(self) -> Option<S>;
 }
 
@@ -701,7 +701,7 @@ impl<CH, CTail> AsRef<Coproduct<CH, CTail>> for Coproduct<CH, CTail> {
 /// Coproducts of unknown type. If you have a Coproduct of known type,
 /// then `co.uninject()` should "just work" even without the trait.
 ///
-/// [`Coproduct::uninject`]: ../enum.Coproduct.html#method.uninject
+/// [`Coproduct::uninject`]: enum.Coproduct.html#method.uninject
 pub trait CoprodUninjector<T, Idx>: CoprodInjector<T, Idx> {
     type Remainder;
 
@@ -713,7 +713,7 @@ pub trait CoprodUninjector<T, Idx>: CoprodInjector<T, Idx> {
     /// trait method is the location of the type parameters.
     /// (here, they are on the trait rather than the method)
     ///
-    /// [inherent method]: ../enum.Coproduct.html#method.uninject
+    /// [inherent method]: enum.Coproduct.html#method.uninject
     fn uninject(self) -> Result<T, Self::Remainder>;
 }
 
@@ -751,7 +751,7 @@ where
 /// Coproducts of unknown type. If you have a Coproduct of known type,
 /// then `co.subset()` should "just work" even without the trait.
 ///
-/// [`Coproduct::subset`]: ../enum.Coproduct.html#method.subset
+/// [`Coproduct::subset`]: enum.Coproduct.html#method.subset
 pub trait CoproductSubsetter<Targets, Indices>: Sized {
     type Remainder;
 
@@ -763,7 +763,7 @@ pub trait CoproductSubsetter<Targets, Indices>: Sized {
     /// trait method is the location of the type parameters.
     /// (here, they are on the trait rather than the method)
     ///
-    /// [inherent method]: ../enum.Coproduct.html#method.subset
+    /// [inherent method]: enum.Coproduct.html#method.subset
     fn subset(self) -> Result<Targets, Self::Remainder>;
 }
 
@@ -803,7 +803,7 @@ impl<Choices> CoproductSubsetter<CNil, HNil> for Choices {
 /// Coproducts of unknown type. If you have a Coproduct of known type,
 /// then `co.embed()` should "just work" even without the trait.
 ///
-/// [`Coproduct::embed`]: ../enum.Coproduct.html#method.embed
+/// [`Coproduct::embed`]: enum.Coproduct.html#method.embed
 pub trait CoproductEmbedder<Out, Indices> {
     /// Convert a coproduct into another that can hold its variants.
     ///
@@ -813,7 +813,7 @@ pub trait CoproductEmbedder<Out, Indices> {
     /// trait method is the location of the type parameters.
     /// (here, they are on the trait rather than the method)
     ///
-    /// [inherent method]: ../enum.Coproduct.html#method.embed
+    /// [inherent method]: enum.Coproduct.html#method.embed
     fn embed(self) -> Out;
 }
 

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -306,15 +306,13 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// // written far more succinctly using `fold`.
     /// fn handle_i32_f32(co: I32F32) -> f32 {
     ///     // Remove i32 from the coproduct
-    ///     let res: Result<i32, _> = co.uninject();
-    ///     let co = match res {
+    ///     let co = match co.uninject::<i32, _>() {
     ///         Ok(x) => return (2 * x) as f32,
     ///         Err(co) => co,
     ///     };
     ///
     ///     // Remove f32 from the coproduct
-    ///     let res: Result<f32, _> = co.uninject();
-    ///     let co = match res {
+    ///     let co = match co.uninject::<f32, _>() {
     ///         Ok(x) => return 2.0 * x,
     ///         Err(co) => co,
     ///     };
@@ -1016,8 +1014,8 @@ mod tests {
             type ABC = Coprod!(A, B, C);
             type BBB = Coprod!(B, B, B);
 
-            let b1 = <BBB as CoprodInjector<B, Here>>::inject(B);
-            let b2 = <BBB as CoprodInjector<B, There<Here>>>::inject(B);
+            let b1 = BBB::inject::<_, Here>(B);
+            let b2 = BBB::inject::<_, There<Here>>(B);
             let out1: ABC = b1.embed();
             let out2: ABC = b2.embed();
             assert_eq!(out1, Coproduct::Inr(Coproduct::Inl(B)));

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -148,11 +148,11 @@ macro_rules! Coprod {
 impl<Head, Tail> Coproduct<Head, Tail> {
     /// Instantiate a coproduct from an element.
     ///
-    /// This is generally much nicer than nested usage of `Coproduct::{Inl,Inr}`.
-    /// It uses a trick with type inference to automatically build the correct variant
+    /// This is generally much nicer than nested usage of `Coproduct::{Inl, Inr}`.
+    /// The method uses a trick with type inference to automatically build the correct variant
     /// according to the input type.
     ///
-    /// In standard usage, the Index type parameter can be ignored,
+    /// In standard usage, the `Index` type parameter can be ignored,
     /// as it will typically be solved for using type inference.
     ///
     /// # Rules

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -305,16 +305,16 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     ///
     /// // Be aware that this particular example could be
     /// // written far more succinctly using `fold`.
-    /// fn handle_i32_f32(co: I32F32) -> f32 {
+    /// fn handle_i32_f32(co: I32F32) -> &'static str {
     ///     // Remove i32 from the coproduct
     ///     let co = match co.uninject::<i32, _>() {
-    ///         Ok(x) => return (2 * x) as f32,
+    ///         Ok(x) => return "integer!",
     ///         Err(co) => co,
     ///     };
     ///
     ///     // Remove f32 from the coproduct
     ///     let co = match co.uninject::<f32, _>() {
-    ///         Ok(x) => return 2.0 * x,
+    ///         Ok(x) => return "float!",
     ///         Err(co) => co,
     ///     };
     ///
@@ -322,8 +322,8 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     ///     match co { /* unreachable */ }
     /// }
     ///
-    /// assert_eq!(handle_i32_f32(I32F32::inject(3)), 6.0);
-    /// assert_eq!(handle_i32_f32(I32F32::inject(3.0)), 6.0);
+    /// assert_eq!(handle_i32_f32(I32F32::inject(3)), "integer!");
+    /// assert_eq!(handle_i32_f32(I32F32::inject(3.0)), "float!");
     /// # }
     #[inline(always)]
     pub fn uninject<T, Index>(self)

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -71,7 +71,7 @@ use hlist::*;
 /// Enum type representing a Coproduct. Think of this as a Result, but capable
 /// of supporting any arbitrary number of types instead of just 2.
 ///
-/// To consctruct a Coproduct, you would typically declare a type using the `Coprod!` type
+/// To construct a Coproduct, you would typically declare a type using the `Coprod!` type
 /// macro and then use the `inject` method.
 ///
 /// # Examples
@@ -158,6 +158,7 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// # Rules
     ///
     /// If the type does not appear in the coproduct, the conversion is forbidden.
+    ///
     /// If the type appears multiple times in the coproduct, type inference will fail.
     ///
     /// # Example
@@ -437,7 +438,9 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// # Rules
     ///
     /// If any type in the input does not appear in the output, the conversion is forbidden.
+    ///
     /// If any type in the input appears multiple times in the output, type inference will fail.
+    ///
     /// All of these rules fall naturally out of its fairly simple definition,
     /// which is equivalent to:
     ///

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -61,7 +61,7 @@ macro_rules! gen_inherent_methods {
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+            /// # #[macro_use] extern crate frunk_core; fn main() {
             /// let h = hlist![1, "hi"];
             /// assert_eq!(h.len(), 2);
             /// # }
@@ -73,12 +73,12 @@ macro_rules! gen_inherent_methods {
                 HList::len(self)
             }
 
-            /// Prepends an item to the current HList
+            /// Prepend an item to the current HList
             ///
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+            /// # #[macro_use] extern crate frunk_core; fn main() {
             /// let h1 = hlist![1, "hi"];
             /// let h2 = h1.prepend(true);
             /// let (a, (b, c)) = h2.into_tuple2();
@@ -93,18 +93,26 @@ macro_rules! gen_inherent_methods {
                 HList::prepend(self, h)
             }
 
-            /// Allows you to retrieve a unique type from an HList
+            /// Borrow an element by type from an HList.
             ///
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
-            /// let h = hlist![1, "hello", true, 42f32];
+            /// # #[macro_use] extern crate frunk_core; fn main() {
+            /// let h = hlist![1i32, 2u32, "hello", true, 42f32];
             ///
-            /// let f: &f32 = h.get();
+            /// // Often, type inference can figure out the type you want.
+            /// // You can help guide type inference when necessary by
+            /// // using type annotations.
             /// let b: &bool = h.get();
-            /// assert_eq!(*f, 42f32);
-            /// assert!(b)
+            /// if !b { panic!("no way!") };
+            ///
+            /// // If space is tight, you can also use turbofish syntax.
+            /// // The Index is still left to type inference by using `_`.
+            /// match *h.get::<u32, _>() {
+            ///     2 => { },
+            ///     _ => panic!("it can't be!!"),
+            /// }
             /// # }
             /// ```
             #[inline(always)]
@@ -114,16 +122,28 @@ macro_rules! gen_inherent_methods {
                 Selector::get(self)
             }
 
-            /// Returns the target with the remainder of the list in a pair
+            /// Remove an element by type from an HList.
+            ///
+            /// The remaining elements are returned along with it.
             ///
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
-            /// let h = hlist![1, "hello", true, 42f32];
-            /// let (t, r): (bool, _) = h.pluck();
-            /// assert!(t);
-            /// assert_eq!(r, hlist![1, "hello", 42f32])
+            /// # #[macro_use] extern crate frunk_core; fn main() {
+            /// let list = hlist![1, "hello", true, 42f32];
+            ///
+            /// // Often, type inference can figure out the target type.
+            /// // This extracts the bool element due to our use of assert!.
+            /// let (b, list): (bool, _) = list.pluck();
+            /// assert!(b);
+            ///
+            /// // When type inference will not suffice, you can use a turbofish.
+            /// // The Index is still left to type inference by using `_`.
+            /// let (s, list) = list.pluck::<i32, _>();
+            ///
+            /// // Each time we plucked, we got back a remainder.
+            /// // Let's check what's left:
+            /// assert_eq!(list, hlist!["hello", 42.0])
             /// # }
             /// ```
             #[inline(always)]
@@ -133,12 +153,18 @@ macro_rules! gen_inherent_methods {
                 Plucker::pluck(self)
             }
 
-            /// Consumes the current HList and returns an HList with the requested shape.
+            /// Consume the current HList and return an HList with the requested shape.
+            ///
+            /// `sculpt` allows us to extract/reshape/scult the current HList into another shape,
+            /// provided that the requested shape's types are are contained within the current HList.
+            ///
+            /// The "Indices" type parameter allows the compiler to figure out that the Target
+            /// and Self can be morphed into each other.
             ///
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+            /// # #[macro_use] extern crate frunk_core; fn main() {
             /// let h = hlist![9000, "joe", 41f32, true];
             /// let (reshaped, remainder): (Hlist![f32, i32, &str], _) = h.sculpt();
             /// assert_eq!(reshaped, hlist![41f32, 9000, "joe"]);
@@ -152,18 +178,18 @@ macro_rules! gen_inherent_methods {
                 Sculptor::sculpt(self)
             }
 
-            /// Reverses a given data structure.
+            /// Reverse the HList.
             ///
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
-            /// let nil = HNil;
+            /// # #[macro_use] extern crate frunk_core; fn main() {
+            /// assert_eq!(hlist![].into_reverse(), hlist![]);
             ///
-            /// assert_eq!(nil.into_reverse(), nil);
-            ///
-            /// let h = hlist![1, "hello", true, 42f32];
-            /// assert_eq!(h.into_reverse(), hlist![42f32, true, "hello", 1])
+            /// assert_eq!(
+            ///     hlist![1, "hello", true, 42f32].into_reverse(),
+            ///     hlist![42f32, true, "hello", 1],
+            /// )
             /// # }
             /// ```
             #[inline(always)]
@@ -190,7 +216,7 @@ impl<Head, Tail> HCons<Head, Tail> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+    /// # #[macro_use] extern crate frunk_core; fn main() {
     /// let h = hlist![1, "hello", true, 42f32];
     ///
     /// // We now have a much nicer pattern matching experience
@@ -220,7 +246,7 @@ pub trait HList: Sized {
     ///
     /// # Examples
     /// ```
-    /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+    /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::HList; fn main() {
     /// assert_eq!(<Hlist![i32, bool, f32] as HList>::LEN, 3);
     /// # }
     /// ```
@@ -236,7 +262,7 @@ pub trait HList: Sized {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+    /// # #[macro_use] extern crate frunk_core; fn main() {
     /// let h = hlist![1, "hi"];
     /// assert_eq!(h.len(), 2);
     /// # }
@@ -251,7 +277,7 @@ pub trait HList: Sized {
     ///
     /// # Examples
     /// ```
-    /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+    /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::HList; fn main() {
     /// assert_eq!(<Hlist![i32, bool, f32] as HList>::static_len(), 3);
     /// # }
     /// ```
@@ -264,7 +290,7 @@ pub trait HList: Sized {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+    /// # #[macro_use] extern crate frunk_core; fn main() {
     /// let h1 = hlist![1, "hi"];
     /// let h2 = h1.prepend(true);
     /// let (a, (b, c)) = h2.into_tuple2();
@@ -285,7 +311,7 @@ pub trait HList: Sized {
 /// # Examples
 ///
 /// ```
-/// # use frunk_core::hlist::*;
+/// # use frunk_core::hlist::{h_cons, HNil};
 ///
 /// let h = h_cons(1, HNil);
 /// let h = h.head;
@@ -337,7 +363,7 @@ impl<H, T> HCons<H, T> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+    /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::HNil; fn main() {
     /// let h = hlist!("hi");
     /// let (h, tail) = h.pop();
     /// assert_eq!(h, "hi");
@@ -377,7 +403,7 @@ pub fn h_cons<H, T: HList>(h: H, tail: T) -> HCons<H, T> {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+/// # #[macro_use] extern crate frunk_core; fn main() {
 /// let h = hlist![13.5f32, "hello", Some(41)];
 /// let (h1, (h2, h3)) = h.into_tuple2();
 /// assert_eq!(h1, 13.5f32);
@@ -425,7 +451,7 @@ macro_rules! hlist {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+/// # #[macro_use] extern crate frunk_core; fn main() {
 /// let h = hlist![13.5f32, "hello", Some(41)];
 /// let hlist_pat![h1, h2, h3] = h;
 /// assert_eq!(h1, 13.5f32);
@@ -453,7 +479,7 @@ macro_rules! hlist_pat {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+/// # #[macro_use] extern crate frunk_core; fn main() {
 /// let h: Hlist!(f32, &str, Option<i32>) = hlist![13.5f32, "hello", Some(41)];
 /// # }
 /// ```
@@ -526,13 +552,26 @@ pub enum Here {}
 #[allow(dead_code)]
 pub struct There<T>(PhantomData<T>);
 
-/// Trait for retrieving an HList element by type
+/// Trait for borrowing an HList element by type
 ///
-/// @@@@@@@@@@@@@@@@@@@@@@@@@@@
+/// This trait is part of the implementation of the inherent method
+/// [`HCons::get`]. Please see that method for more information.
+///
+/// You only need to import this trait when working with generic
+/// HLists of unknown type. If you have an HList of known type,
+/// then `list.get()` should "just work" even without the trait.
+///
+/// [`HCons::get`]: ../struct.HCons.html#method.get
 pub trait Selector<S, I> {
-    /// Allows you to retrieve a unique type from an HList
+    /// Borrow an element by type from an HList.
     ///
-    /// @@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    /// Please see the [inherent method] for more information.
+    ///
+    /// The only difference between that inherent method and this
+    /// trait method is the location of the type parameters.
+    /// (here, they are on the trait rather than the method)
+    ///
+    /// [inherent method]: ../struct.HCons.html#method.get
     fn get(&self) -> &S;
 }
 
@@ -552,15 +591,27 @@ impl<Head, Tail, FromTail, TailIndex> Selector<FromTail, There<TailIndex>> for H
 
 /// Trait defining extraction from a given HList
 ///
-/// Similar to Selector, but returns the target and the remainder of the list (w/o target)
-/// in a pair.
+/// This trait is part of the implementation of the inherent method
+/// [`HCons::pluck`]. Please see that method for more information.
 ///
-/// @@@@@@@@@@@@@@@@@@@@@@@@@@
+/// You only need to import this trait when working with generic
+/// HLists of unknown type. If you have an HList of known type,
+/// then `list.pluck()` should "just work" even without the trait.
+///
+/// [`HCons::pluck`]: ../struct.HCons.html#method.pluck
 pub trait Plucker<Target, Index> {
     /// What is left after you pluck the target from the Self
     type Remainder;
 
-    /// @@@@@@@@@@@@@@@@@@@@@@@@@@@
+    /// Remove an element by type from an HList.
+    ///
+    /// Please see the [inherent method] for more information.
+    ///
+    /// The only difference between that inherent method and this
+    /// trait method is the location of the type parameters.
+    /// (here, they are on the trait rather than the method)
+    ///
+    /// [inherent method]: ../struct.HCons.html#method.pluck
     fn pluck(self) -> (Target, Self::Remainder);
 }
 
@@ -591,19 +642,28 @@ impl<Head, Tail, FromTail, TailIndex> Plucker<FromTail, There<TailIndex>> for HC
     }
 }
 
-/// An Sculptor trait, that allows us to extract/reshape/scult the current HList into another shape,
-/// provided that the requested shape's types are are contained within the current HList.
+/// Trait for pulling out some subset of an HList, using type inference.
 ///
-/// The "Indices" type parameter allows the compiler to figure out that the Target and Self
-/// can be morphed into each other
+/// This trait is part of the implementation of the inherent method
+/// [`HCons::sculpt`]. Please see that method for more information.
 ///
-/// @@@@@@@@@@@@@@@@@@@@@@@@@@@@
+/// You only need to import this trait when working with generic
+/// HLists of unknown type. If you have an HList of known type,
+/// then `list.sculpt()` should "just work" even without the trait.
+///
+/// [`HCons::sculpt`]: ../struct.HCons.html#method.sculpt
 pub trait Sculptor<Target, Indices> {
     type Remainder;
 
     /// Consumes the current HList and returns an HList with the requested shape.
     ///
-    /// @@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    /// Please see the [inherent method] for more information.
+    ///
+    /// The only difference between that inherent method and this
+    /// trait method is the location of the type parameters.
+    /// (here, they are on the trait rather than the method)
+    ///
+    /// [inherent method]: ../struct.HCons.html#method.sculpt
     fn sculpt(self) -> (Target, Self::Remainder);
 }
 
@@ -659,15 +719,16 @@ where
 
 /// Trait that allows for reversing a given data structure.
 ///
-/// Implemented for HCons and HNil.
+/// Implemented for HLists.
 ///
-/// @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+/// This functionality is also provided as an [inherent method].
+/// However, you may find this trait useful in generic contexts.
+///
+/// [inherent method]: ../struct.HCons.html#method.into_reverse
 pub trait IntoReverse {
     type Output;
 
     /// Reverses a given data structure.
-    ///
-    /// @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
     fn into_reverse(self) -> Self::Output;
 }
 
@@ -1090,9 +1151,17 @@ where
     }
 }
 
-/// Trait for things that can be turned into a Tuple 2 (pair)
+/// Trait for transforming an HList into a nested tuple.
 ///
-/// @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+/// This trait is part of the implementation of the inherent method
+/// [`HCons::into_tuple2`]. Please see that method for more information.
+///
+/// This operation is not useful in generic contexts, so it is unlikely
+/// that you should ever need to import this trait. Do not worry;
+/// if you have an HList of known type, then `list.into_tuple2()`
+/// should "just work," even without the trait.
+///
+/// [`HCons::into_tuple2`]: ../struct.HCons.html#method.into_tuple2
 pub trait IntoTuple2 {
     /// The 0 element in the output tuple
     type HeadType;
@@ -1103,7 +1172,9 @@ pub trait IntoTuple2 {
     /// Turns an HList into nested Tuple2s, which are less troublesome to pattern match
     /// and have a nicer type signature.
     ///
-    /// @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    /// Please see the [inherent method] for more information.
+    ///
+    /// [inherent method]: ../struct.HCons.html#method.into_tuple2
     fn into_tuple2(self) -> (Self::HeadType, Self::TailOutput);
 }
 

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -128,7 +128,6 @@ pub trait HList: Sized {
 ///
 /// ```
 /// # use frunk_core::hlist::{h_cons, HNil};
-///
 /// let h = h_cons(1, HNil);
 /// let h = h.head;
 /// assert_eq!(h, 1);

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -562,7 +562,7 @@ pub struct There<T>(PhantomData<T>);
 /// HLists of unknown type. If you have an HList of known type,
 /// then `list.get()` should "just work" even without the trait.
 ///
-/// [`HCons::get`]: ../struct.HCons.html#method.get
+/// [`HCons::get`]: struct.HCons.html#method.get
 pub trait Selector<S, I> {
     /// Borrow an element by type from an HList.
     ///
@@ -572,7 +572,7 @@ pub trait Selector<S, I> {
     /// trait method is the location of the type parameters.
     /// (here, they are on the trait rather than the method)
     ///
-    /// [inherent method]: ../struct.HCons.html#method.get
+    /// [inherent method]: struct.HCons.html#method.get
     fn get(&self) -> &S;
 }
 
@@ -599,7 +599,7 @@ impl<Head, Tail, FromTail, TailIndex> Selector<FromTail, There<TailIndex>> for H
 /// HLists of unknown type. If you have an HList of known type,
 /// then `list.pluck()` should "just work" even without the trait.
 ///
-/// [`HCons::pluck`]: ../struct.HCons.html#method.pluck
+/// [`HCons::pluck`]: struct.HCons.html#method.pluck
 pub trait Plucker<Target, Index> {
     /// What is left after you pluck the target from the Self
     type Remainder;
@@ -612,7 +612,7 @@ pub trait Plucker<Target, Index> {
     /// trait method is the location of the type parameters.
     /// (here, they are on the trait rather than the method)
     ///
-    /// [inherent method]: ../struct.HCons.html#method.pluck
+    /// [inherent method]: struct.HCons.html#method.pluck
     fn pluck(self) -> (Target, Self::Remainder);
 }
 
@@ -652,7 +652,7 @@ impl<Head, Tail, FromTail, TailIndex> Plucker<FromTail, There<TailIndex>> for HC
 /// HLists of unknown type. If you have an HList of known type,
 /// then `list.sculpt()` should "just work" even without the trait.
 ///
-/// [`HCons::sculpt`]: ../struct.HCons.html#method.sculpt
+/// [`HCons::sculpt`]: struct.HCons.html#method.sculpt
 pub trait Sculptor<Target, Indices> {
     type Remainder;
 
@@ -664,7 +664,7 @@ pub trait Sculptor<Target, Indices> {
     /// trait method is the location of the type parameters.
     /// (here, they are on the trait rather than the method)
     ///
-    /// [inherent method]: ../struct.HCons.html#method.sculpt
+    /// [inherent method]: struct.HCons.html#method.sculpt
     fn sculpt(self) -> (Target, Self::Remainder);
 }
 
@@ -725,7 +725,7 @@ where
 /// This functionality is also provided as an [inherent method].
 /// However, you may find this trait useful in generic contexts.
 ///
-/// [inherent method]: ../struct.HCons.html#method.into_reverse
+/// [inherent method]: struct.HCons.html#method.into_reverse
 pub trait IntoReverse {
     type Output;
 
@@ -1162,7 +1162,7 @@ where
 /// if you have an HList of known type, then `list.into_tuple2()`
 /// should "just work," even without the trait.
 ///
-/// [`HCons::into_tuple2`]: ../struct.HCons.html#method.into_tuple2
+/// [`HCons::into_tuple2`]: struct.HCons.html#method.into_tuple2
 pub trait IntoTuple2 {
     /// The 0 element in the output tuple
     type HeadType;
@@ -1175,7 +1175,7 @@ pub trait IntoTuple2 {
     ///
     /// Please see the [inherent method] for more information.
     ///
-    /// [inherent method]: ../struct.HCons.html#method.into_tuple2
+    /// [inherent method]: struct.HCons.html#method.into_tuple2
     fn into_tuple2(self) -> (Self::HeadType, Self::TailOutput);
 }
 

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -52,6 +52,7 @@
 use std::ops::Add;
 use std::marker::PhantomData;
 
+// Inherent methods shared by HNil and HCons.
 macro_rules! gen_inherent_methods {
     (impl<$($TyPar:ident),*> $Struct:ty { ... })
     => {
@@ -91,66 +92,6 @@ macro_rules! gen_inherent_methods {
             where Self: HList,
             {
                 HList::prepend(self, h)
-            }
-
-            /// Borrow an element by type from an HList.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// # #[macro_use] extern crate frunk_core; fn main() {
-            /// let h = hlist![1i32, 2u32, "hello", true, 42f32];
-            ///
-            /// // Often, type inference can figure out the type you want.
-            /// // You can help guide type inference when necessary by
-            /// // using type annotations.
-            /// let b: &bool = h.get();
-            /// if !b { panic!("no way!") };
-            ///
-            /// // If space is tight, you can also use turbofish syntax.
-            /// // The Index is still left to type inference by using `_`.
-            /// match *h.get::<u32, _>() {
-            ///     2 => { },
-            ///     _ => panic!("it can't be!!"),
-            /// }
-            /// # }
-            /// ```
-            #[inline(always)]
-            pub fn get<T, Index>(&self) -> &T
-            where Self: Selector<T, Index>,
-            {
-                Selector::get(self)
-            }
-
-            /// Remove an element by type from an HList.
-            ///
-            /// The remaining elements are returned along with it.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// # #[macro_use] extern crate frunk_core; fn main() {
-            /// let list = hlist![1, "hello", true, 42f32];
-            ///
-            /// // Often, type inference can figure out the target type.
-            /// // This extracts the bool element due to our use of assert!.
-            /// let (b, list): (bool, _) = list.pluck();
-            /// assert!(b);
-            ///
-            /// // When type inference will not suffice, you can use a turbofish.
-            /// // The Index is still left to type inference by using `_`.
-            /// let (s, list) = list.pluck::<i32, _>();
-            ///
-            /// // Each time we plucked, we got back a remainder.
-            /// // Let's check what's left:
-            /// assert_eq!(list, hlist!["hello", 42.0])
-            /// # }
-            /// ```
-            #[inline(always)]
-            pub fn pluck<T, Index>(self) -> (T, <Self as Plucker<T, Index>>::Remainder)
-            where Self: Plucker<T, Index>
-            {
-                Plucker::pluck(self)
             }
 
             /// Consume the current HList and return an HList with the requested shape.
@@ -209,7 +150,68 @@ gen_inherent_methods!{
     impl<Head, Tail> HCons<Head, Tail> { ... }
 }
 
+// HCons-only inherent methods.
 impl<Head, Tail> HCons<Head, Tail> {
+    /// Borrow an element by type from an HList.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[macro_use] extern crate frunk_core; fn main() {
+    /// let h = hlist![1i32, 2u32, "hello", true, 42f32];
+    ///
+    /// // Often, type inference can figure out the type you want.
+    /// // You can help guide type inference when necessary by
+    /// // using type annotations.
+    /// let b: &bool = h.get();
+    /// if !b { panic!("no way!") };
+    ///
+    /// // If space is tight, you can also use turbofish syntax.
+    /// // The Index is still left to type inference by using `_`.
+    /// match *h.get::<u32, _>() {
+    ///     2 => { },
+    ///     _ => panic!("it can't be!!"),
+    /// }
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn get<T, Index>(&self) -> &T
+    where Self: Selector<T, Index>,
+    {
+        Selector::get(self)
+    }
+
+    /// Remove an element by type from an HList.
+    ///
+    /// The remaining elements are returned along with it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[macro_use] extern crate frunk_core; fn main() {
+    /// let list = hlist![1, "hello", true, 42f32];
+    ///
+    /// // Often, type inference can figure out the target type.
+    /// // This extracts the bool element due to our use of assert!.
+    /// let (b, list): (bool, _) = list.pluck();
+    /// assert!(b);
+    ///
+    /// // When type inference will not suffice, you can use a turbofish.
+    /// // The Index is still left to type inference by using `_`.
+    /// let (s, list) = list.pluck::<i32, _>();
+    ///
+    /// // Each time we plucked, we got back a remainder.
+    /// // Let's check what's left:
+    /// assert_eq!(list, hlist!["hello", 42.0])
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn pluck<T, Index>(self) -> (T, <Self as Plucker<T, Index>>::Remainder)
+    where Self: Plucker<T, Index>
+    {
+        Plucker::pluck(self)
+    }
+
     /// Turns an HList into nested Tuple2s, which are less troublesome to pattern match
     /// and have a nicer type signature.
     ///

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -258,8 +258,8 @@ macro_rules! gen_inherent_methods {
             /// `sculpt` allows us to extract/reshape/scult the current HList into another shape,
             /// provided that the requested shape's types are are contained within the current HList.
             ///
-            /// The "Indices" type parameter allows the compiler to figure out that the Target
-            /// and Self can be morphed into each other.
+            /// The `Indices` type parameter allows the compiler to figure out that `Ts`
+            /// and `Self` can be morphed into each other.
             ///
             /// # Examples
             ///

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -352,7 +352,6 @@ impl<Head, Tail> HCons<Head, Tail> {
     /// let list = hlist![1, "hello", true, 42f32];
     ///
     /// // Often, type inference can figure out the target type.
-    /// // This extracts the bool element due to our use of assert!.
     /// let (b, list): (bool, _) = list.pluck();
     /// assert!(b);
     ///


### PR DESCRIPTION
Okay, I think this is ready.

---

**Todo:**
* ~Thoroughly look over the documentation and:~
    * ~Make sure method order is nice~
    * ~Double check content of docstrings~
    * ~Double check all links~

---

<details>
<summary>Original text</summary>
This currently just covers HList because I wanted to know if there is any feedback before continuing with Coproduct.

The actual addition of the inherent methods is only a small part of this.  By far the biggest aspect of such a feature is documentation, because without good documentation, having both the trait methods and the inherent methods will create confusion.

* Docs on traits were moved to the new methods where appropriate.
* Examples in `hlist.rs` are adjusted to show turbofish
* Most trait docs have significantly changed.
  * `Selector`, `Sculptor`, `Plucker` all direct the reader's attention toward the inherent method, leaving the trait for just generic code.
  * IntoTuple2 says "you should never need to import this trait" because it is not useful in generic code.
  * IntoReverse was allowed to keep its headline.  (I can see other types implementing it in the future.)  It just casually remarks "This functionality is also provided as an inherent method."

</details>