### PR TITLE
Introduce a Poly wrapper struct and Func trait for order-free mapping

### DIFF
--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -609,10 +609,10 @@ pub trait CoproductFoldable<Folder, Output> {
     fn fold(self, f: Folder) -> Output;
 }
 
-impl <P, R, CH, CTail> CoproductFoldable<Poly<P>, R> for Coproduct<CH, CTail>
+impl<P, R, CH, CTail> CoproductFoldable<Poly<P>, R> for Coproduct<CH, CTail>
 where
-  P: Func<CH, Output = R>,
-  CTail: CoproductFoldable<Poly<P>, R>,
+    P: Func<CH, Output = R>,
+    CTail: CoproductFoldable<Poly<P>, R>,
 {
     fn fold(self, f: Poly<P>) -> R {
         use self::Coproduct::*;

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -672,9 +672,6 @@ where
 /// HList traits that take a simple unwrapped closure.
 pub struct Poly<T>(pub T);
 
-// Special index type for Poly; essentially ignored
-pub enum PolyIndex {}
-
 /// This is a simple, user-implementable version of Fn.
 ///
 /// Might not be necessary if/when Fn(Once, Mut) traits are implementable
@@ -685,21 +682,12 @@ pub trait Func<Input> {
     fn call(i: Input) -> Self::Output;
 }
 
-impl<P> HMappable<Poly<P>, PolyIndex> for HNil
-{
-    type Output = HNil;
-
-    fn map(self, _: Poly<P>) -> Self::Output {
-        HNil
-    }
-}
-
-impl<P, H, Tail> HMappable<Poly<P>, PolyIndex> for HCons<H, Tail>
+impl<P, H, Tail> HMappable<Poly<P>> for HCons<H, Tail>
 where
     P: Func<H>,
-    Tail: HMappable<Poly<P>, PolyIndex>,
+    Tail: HMappable<Poly<P>>,
 {
-    type Output = HCons<<P as Func<H>>::Output, <Tail as HMappable<Poly<P>, PolyIndex>>::Output>;
+    type Output = HCons<<P as Func<H>>::Output, <Tail as HMappable<Poly<P>>>::Output>;
     fn map(self, poly: Poly<P>) -> Self::Output {
         HCons {
             head: P::call(self.head),

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -663,17 +663,26 @@ where
     }
 }
 
-// Thin wrapper for discriminating against just F
+/// This is a thin generic wrapper type that is used to differentiate
+/// between single-typed generic closure F that implements, say, Fn<i8> -> bool,
+/// and a Poly-typed F that implements multiple Function types, say
+/// Func<i8, bool>, Fun<bool, f32> etc.
+///
+/// This is needed because there are completely generic impls for many of the
+/// HList traits that take a simple unwrapped closure.
 pub struct Poly<T>(pub T);
 
 // Special index type for Poly; essentially ignored
 pub enum PolyIndex {}
 
-// Essentially just Func
-pub trait Func<In> {
+/// This is a simple, user-implementable version of Fn.
+///
+/// Might not be necessary if/when Fn(Once, Mut) traits are implementable
+/// in stable Rust
+pub trait Func<Input> {
     type Output;
 
-    fn call(i: In) -> Self::Output;
+    fn call(i: Input) -> Self::Output;
 }
 
 impl<P> HMappable<Poly<P>, PolyIndex> for HNil

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -1347,7 +1347,7 @@ mod tests {
                 args > 100
             }
         }
-        impl <'a> Func<&'a str> for P {
+        impl<'a> Func<&'a str> for P {
             type Output = usize;
             fn call(args: &'a str) -> Self::Output {
                 args.len()
@@ -1366,26 +1366,29 @@ mod tests {
     #[test]
     fn test_poly_map_non_consuming() {
         let h = hlist![9000, "joe", 41f32, "schmoe", 50];
-        impl <'a> Func<&'a i32> for P {
+        impl<'a> Func<&'a i32> for P {
             type Output = bool;
             fn call(args: &'a i32) -> Self::Output {
                 *args > 100
             }
         }
-        impl <'a> Func<&'a &'a str> for P {
+        impl<'a> Func<&'a &'a str> for P {
             type Output = usize;
             fn call(args: &'a &'a str) -> Self::Output {
                 args.len()
             }
         }
-        impl <'a> Func<&'a f32> for P {
+        impl<'a> Func<&'a f32> for P {
             type Output = String;
             fn call(args: &'a f32) -> Self::Output {
                 format!("{}", args)
             }
         }
         struct P;
-        assert_eq!(h.to_ref().map(Poly(P)), hlist![true, 3, "41".to_string(), 6, false]);
+        assert_eq!(
+            h.to_ref().map(Poly(P)),
+            hlist![true, 3, "41".to_string(), 6, false]
+        );
     }
 
     #[test]

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -1364,6 +1364,31 @@ mod tests {
     }
 
     #[test]
+    fn test_poly_map_non_consuming() {
+        let h = hlist![9000, "joe", 41f32, "schmoe", 50];
+        impl <'a> Func<&'a i32> for P {
+            type Output = bool;
+            fn call(args: &'a i32) -> Self::Output {
+                *args > 100
+            }
+        }
+        impl <'a> Func<&'a &'a str> for P {
+            type Output = usize;
+            fn call(args: &'a &'a str) -> Self::Output {
+                args.len()
+            }
+        }
+        impl <'a> Func<&'a f32> for P {
+            type Output = String;
+            fn call(args: &'a f32) -> Self::Output {
+                format!("{}", args)
+            }
+        }
+        struct P;
+        assert_eq!(h.to_ref().map(Poly(P)), hlist![true, 3, "41".to_string(), 6, false]);
+    }
+
+    #[test]
     fn test_map_single_func_consuming() {
         let h = hlist![9000, 9001, 9002];
         let mapped = h.map(|v| v + 1);

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -28,11 +28,15 @@
 //! assert_eq!(folded, 9001);
 //!
 //! let h3 = hlist![9000, "joe", 41f32];
-//! // Mapping over an HList (we use to_ref() to map over the HList without consuming it,
-//! // but you can use the value-consuming version by leaving it off.)
-//! let mapped = h3.to_ref().map(hlist![|&n| n + 1,
-//!                                     |&s| s,
-//!                                     |&f| f + 1f32]);
+//! // Mapping over an HList with a polymorphic function,
+//! // declared using the poly_fn! macro (you can choose to impl
+//! // it manually)
+//! let mapped = h3.map(
+//!   poly_fn![
+//!     |f: f32|   -> f32 { f + 1f32 },
+//!     |i: isize| -> isize { i + 1 },
+//!     ['a] |s: &'a str| -> &'a str { s }
+//!   ]);
 //! assert_eq!(mapped, hlist![9001, "joe", 42f32]);
 //!
 //! // Plucking a value out by type

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -284,14 +284,14 @@ macro_rules! poly_fn {
         $(
             impl<$($pars,)*> $crate::hlist::Func<$p_arg_typ> for F {
                 type Output = $p_ret_typ;
-                #[allow(unused)]
+
                 fn call($p_args: $p_arg_typ) -> Self::Output { $p_body }
             }
         )*
         $(
             impl $crate::hlist::Func<$arg_typ> for F {
                 type Output = $ret_typ;
-                #[allow(unused)]
+
                 fn call($args: $arg_typ) -> Self::Output { $body }
             }
         )*
@@ -382,9 +382,9 @@ mod tests {
 
         let co1 = I32F32StrBool::inject("lollerskates");
         let folded = co1.fold(poly_fn!(
-            ['a] |x: &'a str| -> i8 { 1 },
-            |x: i32| -> i8 { 2 },
-            |f: f32| -> i8 { 3 },
+            ['a] |_x: &'a str| -> i8 { 1 },
+            |_x: i32| -> i8 { 2 },
+            |_f: f32| -> i8 { 3 },
         ));
         assert_eq!(folded, 1);
     }


### PR DESCRIPTION
### Overview

This is just a PoC for discussion to garner feedback, thoughts, etc :)

### Motivation

We already have a `.map` on HList that works by passing another HList of transformation functions for each element.

It might also be convenient map by simply having transformation functions for every type in the HList. That way

  1. Order of declaration of the transformation functions doesn't matter
  2. Remove the need to specify the same transformation more than once.

This PoC PR attempts to make this happen, introducing the following

```rust
let h = hlist![9000, "joe", 41f32, "schmoe", 50];

struct P;

impl Func<i32> for P {
    type Output = bool;
    fn call(args: i32) -> Self::Output {
        args > 100
    }
}
impl <'a> Func<&'a str> for P {
    type Output = usize;
    fn call(args: &'a str) -> Self::Output {
        args.len()
    }
}
impl Func<f32> for P {
    type Output = String;
    fn call(args: f32) -> Self::Output {
        format!("{}", args)
    }
}

assert_eq!(h.map(Poly(P)), hlist![true, 3, "41".to_string(), 6, false]);
```

The `Poly` is so we don't clash with existing `impl` for mapping over a single-element HList with a function.

### Changes

- Introduce a Poly wrapper struct and Func trait
- Add implementation of HMapper for when a given type
   implemenents Func for all types inside an HList
   and is passed to .map while wrapped in a Poly