### PR TITLE
Remove redundant AsRef implementations and &'a-based trait impls.

### DIFF
--- a/benches/hlist.rs
+++ b/benches/hlist.rs
@@ -47,3 +47,35 @@ fn hlist_append(b: &mut Bencher) {
     let h2 = hlist![true, "blue", "varcity"];
     b.iter(|| h1 + h2)
 }
+
+#[bench]
+fn hlist_mapping_consuming(b: &mut Bencher) {
+    let h1 = hlist![1, 2, 3.3f32, "hi2", true];
+    b.iter(|| {
+        h1.map(
+            hlist![
+              |i| i + 1,
+              |i| i + 2,
+              |i| i + 3f32,
+              |s| s,
+              |b: bool| !b,
+            ]
+        );
+    });
+}
+
+#[bench]
+fn hlist_mapping_non_consuming(b: &mut Bencher) {
+    let h1 = hlist![1, 2, 3.3f32, "hi2", true];
+    b.iter(|| {
+        h1.to_ref().map(
+            hlist![
+              |&i| i + 1,
+              |&i| i + 2,
+              |&i| i + 3f32,
+              |&s| s,
+              |&b: &bool| !b,
+            ]
+        );
+    });
+}

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -799,23 +799,25 @@ where
 ///
 /// This is essentially From, but the more specific nature of it means it's more ergonomic
 /// in actual usage
-pub trait ToRef {
+pub trait ToRef<'a> {
     type Output;
-    fn to_ref(self) -> Self::Output;
+    fn to_ref(&'a self) -> Self::Output;
 }
 
-impl <'a> ToRef for &'a HNil {
+impl <'a>  ToRef<'a> for HNil {
     type Output = &'a HNil;
-    fn to_ref(self) -> Self::Output {
+    fn to_ref(&'a self) -> Self::Output {
         &HNil
     }
 
 }
 
-impl <'a, H, Tail> ToRef for &'a HCons<H, Tail>
-where &'a Tail: ToRef {
-    type Output = HCons<&'a H, <&'a Tail as ToRef>::Output>;
-    fn to_ref(self) -> Self::Output {
+impl <'a, H, Tail> ToRef<'a> for HCons<H, Tail>
+where
+    H: 'a,
+    Tail: ToRef<'a> {
+    type Output = HCons<&'a H, <Tail as ToRef<'a>>::Output>;
+    fn to_ref(&'a self) -> Self::Output {
         HCons {
             head: &self.head,
             tail: (&self.tail).to_ref()

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -814,6 +814,13 @@ where
 ///
 /// This is essentially From, but the more specific nature of it means it's more ergonomic
 /// in actual usage.
+///
+/// Implemented for HLists.
+///
+/// This functionality is also provided as an [inherent method].
+/// However, you may find this trait useful in generic contexts.
+///
+/// [inherent method]: struct.HCons.html#method.to_ref
 pub trait ToRef<'a> {
     type Output;
 
@@ -831,9 +838,9 @@ impl<'a> ToRef<'a> for HNil {
 }
 
 impl<'a, H, Tail> ToRef<'a> for HCons<H, Tail>
-    where
-        H: 'a,
-        Tail: ToRef<'a>,
+where
+    H: 'a,
+    Tail: ToRef<'a>,
 {
     type Output = HCons<&'a H, <Tail as ToRef<'a>>::Output>;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! // Mapping over an HList
 //! let h3 = hlist![9000, "joe", 41f32];
-//! let mapped = (&h3).map(hlist![|&n| n + 1,
+//! let mapped = h3.to_ref().map(hlist![|&n| n + 1,
 //!                               |&s| s,
 //!                               |&f| f + 1f32]);
 //! assert_eq!(mapped, hlist![9001, "joe", 42f32]);


### PR DESCRIPTION
This helps us avoid overflows when implementing our recursive traits (e.g. https://github.com/lloydmeta/frunk/pull/106#issuecomment-377927198). 

Instead, introduce a `ToRef` trait and impls that allows us to turn `&'a HCons<H, Tail>` into `HCons<&'a H, <&'a Tail as ToRef>::Output>`.

Unlike `AsRef`, we are not restricted to having to return a `&T`.

See https://github.com/lloydmeta/frunk/pull/106#issuecomment-377957019

Note I couldn't really make this work with the `Hlist!` type macro I needed to use the associated `Output` type from the tail implementation.