### PR TITLE
The Great Glob Import Extinction (and requisite finishing touches)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Statically typed heterogeneous lists.
 First, let's enable `hlist`:
 ```rust
 #[macro_use] extern crate frunk; // allows us to use the handy hlist! macro
-use frunk_core::hlist::*;
+use frunk::{HNil, HCons};
 ```
 
 Some basics:

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,3 +17,7 @@ serde = { version = "^1.0", optional = true, features = [ "derive" ] }
 [dev-dependencies.frunk_derives]
 path = "../derives"
 version = "0.0.24"
+
+[dev-dependencies.frunk]
+path = ".."
+version = "0.1.36"

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -72,6 +72,7 @@
 //! ```
 
 use hlist::*;
+use indices::{Here, There};
 
 /// Enum type representing a Coproduct. Think of this as a Result, but capable
 /// of supporting any arbitrary number of types instead of just 2.

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -450,13 +450,15 @@ impl<Head, Tail> Coproduct<Head, Tail> {
         CoproductEmbedder::embed(self)
     }
 
-    /// (XXX from trait XXX)
+    /// Use functions to transform a Coproduct into a single value.
     ///
-    /// Trait for implementing "folding" a Coproduct into a value.
+    /// A variety of types are supported for the `Folder` argument:
     ///
-    /// The Folder should be an HList of closures that correspond to the
-    /// types used in declaring the Coproduct type, or a value of a type
-    /// that implements Func for all the types in the Coproduct.
+    /// * An `hlist![]` of closures (one for each type, in order).
+    /// * A single closure (for a Coproduct that is homogenous).
+    /// * A single [`Poly`].
+    ///
+    /// [`Poly`]: ../hlist/struct.Poly.html
     ///
     /// # Example
     ///
@@ -658,8 +660,27 @@ where
     }
 }
 
-// FIXME
+/// Trait for folding a coproduct into a single value.
+///
+/// This trait is part of the implementation of the inherent method
+/// [`Coproduct::fold`]. Please see that method for more information.
+///
+/// You only need to import this trait when working with generic
+/// Coproducts or Folders of unknown type. If the type of everything is known,
+/// then `co.fold(folder)` should "just work" even without the trait.
+///
+/// [`Coproduct::fold`]: enum.Coproduct.html#method.fold
 pub trait CoproductFoldable<Folder, Output> {
+
+    /// Use functions to fold a coproduct into a single value.
+    ///
+    /// Please see the [inherent method] for more information.
+    ///
+    /// The only difference between that inherent method and this
+    /// trait method is the location of the type parameters.
+    /// (here, they are on the trait rather than the method)
+    ///
+    /// [inherent method]: enum.Coproduct.html#method.fold
     fn fold(self, f: Folder) -> Output;
 }
 

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -3,8 +3,9 @@
 //! Think of "Coproduct" as ad-hoc enums; allowing you to do something like this
 //!
 //! ```
-//! # #[macro_use] extern crate frunk_core;
-//! # use frunk_core::coproduct::*;
+//! #[macro_use]
+//! extern crate frunk;
+//!
 //! # fn main() {
 //! // For simplicity, assign our Coproduct type to a type alias
 //! // This is purely optional.
@@ -39,32 +40,30 @@
 //! Or, if you want to "fold" over all possible values of a coproduct
 //!
 //! ```
-//! # #[macro_use] extern crate frunk_core;
-//! # use frunk_core::hlist::*;
-//! # use frunk_core::coproduct::*;
+//! # #[macro_use] extern crate frunk;
 //! # fn main() {
 //! # type I32Bool = Coprod!(i32, bool);
 //! # let co1 = I32Bool::inject(3);
 //! # let co2 = I32Bool::inject(true);
-//! // In the below, we use unimplemented!() to make it obvious hat we know what type of
+//! // In the below, we use unreachable!() to make it obvious hat we know what type of
 //! // item is inside our coproducts co1 and co2 but in real life, you should be writing
 //! // complete functions for all the cases when folding coproducts
+//! //
+//! // to_ref borrows every item so that we can fold without consuming the coproduct.
 //! assert_eq!(
 //!     co1.to_ref().fold(hlist![|&i| format!("i32 {}", i),
-//!                              |&b| unimplemented!() /* we know this won't happen for co1 */ ]),
+//!                              |&b| unreachable!() /* we know this won't happen for co1 */ ]),
 //!     "i32 3".to_string());
 //! assert_eq!(
-//!     co2.to_ref().fold(hlist![|&i| unimplemented!() /* we know this won't happen for co2 */,
+//!     co2.to_ref().fold(hlist![|&i| unreachable!() /* we know this won't happen for co2 */,
 //!                              |&b| String::from(if b { "t" } else { "f" })]),
 //!     "t".to_string());
-//!
-//! // There is also a value consuming-variant of fold
 //!
 //! // Here, we use the poly_fn! macro to declare a polymorphic function to avoid caring
 //! // about the order in which declare handlers for the types in our coproduct
 //! let folded = co1.fold(
 //!       poly_fn![
-//!         |_b: bool| -> String { unimplemented!() }, /* we know this won't happen for co1 */
+//!         |_b: bool| -> String { unreachable!() }, /* we know this won't happen for co1 */
 //!         |i:  i32 | -> String { format!("i32 {}", i) },
 //!       ]
 //!      );
@@ -83,8 +82,7 @@ use hlist::*;
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core;
-/// # use frunk_core::coproduct::*;
+/// # #[macro_use] extern crate frunk;
 /// # fn main() {
 /// type I32Bool = Coprod!(i32, bool);
 /// let co1 = I32Bool::inject(3);
@@ -130,9 +128,9 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// # Example
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core;
+    /// # #[macro_use] extern crate frunk;
     /// # fn main() {
-    /// use frunk_core::coproduct::Coproduct;
+    /// use frunk::Coproduct;
     ///
     /// type I32F32 = Coprod!(i32, f32);
     ///
@@ -172,7 +170,7 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// # Example
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core;
+    /// # #[macro_use] extern crate frunk;
     /// # fn main() {
     /// type I32F32 = Coprod!(i32, f32);
     ///
@@ -203,7 +201,7 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// # Example
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core;
+    /// # #[macro_use] extern crate frunk;
     /// # fn main() {
     /// type I32F32 = Coprod!(i32, f32);
     ///
@@ -238,7 +236,7 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// Basic usage:
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core;
+    /// # #[macro_use] extern crate frunk;
     /// # fn main() {
     /// type I32F32 = Coprod!(i32, f32);
     /// type I32 = Coprod!(i32); // remainder after uninjecting f32
@@ -268,7 +266,7 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// Chaining calls for an exhaustive match:
     ///
     /// ```rust
-    /// # #[macro_use] extern crate frunk_core;
+    /// # #[macro_use] extern crate frunk;
     /// # fn main() {
     /// type I32F32 = Coprod!(i32, f32);
     ///
@@ -318,8 +316,9 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// Basic usage:
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core;
-    /// # use ::frunk_core::coproduct::Coproduct;
+    /// # #[macro_use] extern crate frunk;
+    /// use ::frunk::Coproduct;
+    ///
     /// # fn main() {
     /// type I32BoolF32 = Coprod!(i32, bool, f32);
     /// type I32F32 = Coprod!(i32, f32);
@@ -346,8 +345,9 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// with the advantage that it can remove more than one type at a time:
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core;
-    /// # use frunk_core::coproduct::*;
+    /// # #[macro_use] extern crate frunk;
+    /// use frunk::Coproduct;
+    ///
     /// # fn main() {
     /// fn handle_stringly_things(co: Coprod!(&'static str, String)) -> String {
     ///     co.fold(hlist![
@@ -427,7 +427,7 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// # Example
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core;
+    /// # #[macro_use] extern crate frunk;
     /// # fn main() {
     /// type I32BoolF32 = Coprod!(i32, bool, f32);
     /// type BoolI32 = Coprod!(bool, i32);
@@ -458,8 +458,8 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// consuming the coproduct:
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core; fn main() {
-    /// # use frunk_core::coproduct::Coproduct;
+    /// # #[macro_use] extern crate frunk; fn main() {
+    /// use frunk::Coproduct;
     ///
     /// let co: Coprod!(i32, bool, String) = Coproduct::inject(true);
     ///
@@ -486,9 +486,7 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// # Example
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core;
-    /// # use frunk_core::coproduct::*;
-    /// # use frunk_core::hlist::*;
+    /// # #[macro_use] extern crate frunk;
     /// # fn main() {
     /// type I32F32StrBool = Coprod!(i32, f32, bool);
     ///
@@ -509,10 +507,10 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// handlers for the types in your Coproduct.
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core;
-    /// # use frunk_core::coproduct::*;
-    /// # use frunk_core::hlist::*;
+    /// # #[macro_use] extern crate frunk;
     /// # fn main() {
+    /// use frunk::{Poly, Func};
+    ///
     /// type I32F32StrBool = Coprod!(i32, f32, bool);
     ///
     /// impl Func<i32> for P {

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -483,7 +483,7 @@ impl<Head, Tail> Coproduct<Head, Tail> {
     /// * A single closure (for a Coproduct that is homogenous).
     /// * A single [`Poly`].
     ///
-    /// [`Poly`]: ../hlist/struct.Poly.html
+    /// [`Poly`]: ../traits/struct.Poly.html
     ///
     /// # Example
     ///

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -71,8 +71,9 @@
 //! # }
 //! ```
 
-use hlist::*;
+use hlist::{HNil, HCons};
 use indices::{Here, There};
+use traits::{Poly, Func, ToRef};
 
 /// Enum type representing a Coproduct. Think of this as a Result, but capable
 /// of supporting any arbitrary number of types instead of just 2.

--- a/core/src/generic.rs
+++ b/core/src/generic.rs
@@ -6,12 +6,10 @@
 //! # Examples
 //!
 //! ```rust
-//! # #[allow(unused_imports)]
-//! # #[macro_use] extern crate frunk_derives;
-//! # #[macro_use] extern crate frunk_core;
-//! # use frunk_core::hlist::*; fn main() {
-//! # use frunk_core::hlist::*;
-//! # use frunk_core::generic::*;
+//! #[macro_use] extern crate frunk;
+//! #[macro_use] extern crate frunk_core;
+//!
+//! # fn main() {
 //! #[derive(Generic)]
 //! struct ApiPerson<'a> {
 //!     FirstName: &'a str,
@@ -31,7 +29,7 @@
 //!     LastName: "Blow",
 //!     Age: 30,
 //! };
-//! let d_person: DomainPerson = convert_from(a_person); // done
+//! let d_person: DomainPerson = frunk::convert_from(a_person); // done
 //! # }
 
 /// A trait that converts from a type to a generic representation
@@ -42,12 +40,10 @@
 /// # Examples
 ///
 /// ```rust
-/// # #[allow(unused_imports)]
-/// # #[macro_use] extern crate frunk_derives;
-/// # #[macro_use] extern crate frunk_core;
-/// # use frunk_core::hlist::*; fn main() {
-/// use frunk_core::hlist::*;
-/// use frunk_core::generic::*;
+/// #[macro_use] extern crate frunk;
+/// #[macro_use] extern crate frunk_core;
+///
+/// # fn main() {
 /// #[derive(Generic)]
 /// struct ApiPerson<'a> {
 ///     FirstName: &'a str,
@@ -67,7 +63,7 @@
 ///     LastName: "Blow",
 ///     Age: 30,
 /// };
-/// let d_person: DomainPerson = convert_from(a_person); // done
+/// let d_person: DomainPerson = frunk::convert_from(a_person); // done
 /// # }
 /// ```
 pub trait Generic {

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -56,6 +56,8 @@
 //! # }
 //! ```
 
+use indices::{Here, There, Suffixed};
+
 use std::ops::Add;
 
 /// Typeclass for HList-y behaviour
@@ -638,9 +640,6 @@ where
         }
     }
 }
-
-// FIXME kill this one examples are updated
-pub use ::indices::{Here, There, Suffixed};
 
 /// Trait for borrowing an HList element by type
 ///

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -841,22 +841,32 @@ where
     }
 }
 
+/// Wrapper type around a function for polymorphic maps and folds.
+///
 /// This is a thin generic wrapper type that is used to differentiate
-/// between single-typed generic closure F that implements, say, Fn<i8> -> bool,
-/// and a Poly-typed F that implements multiple Function types, say
-/// Func<i8, bool>, Fun<bool, f32> etc.
+/// between single-typed generic closures `F` that implements, say, `Fn(i8) -> bool`,
+/// and a Poly-typed `F` that implements multiple Function types, say
+/// `Func<i8, Output=bool>`, `Func<bool, Output=f32>` etc.
 ///
 /// This is needed because there are completely generic impls for many of the
 /// HList traits that take a simple unwrapped closure.
+#[derive(Debug, Copy, Clone, Default)]
 pub struct Poly<T>(pub T);
 
-/// This is a simple, user-implementable version of Fn.
+/// This is a simple, user-implementable alternative to `Fn`.
 ///
 /// Might not be necessary if/when Fn(Once, Mut) traits are implementable
 /// in stable Rust
 pub trait Func<Input> {
     type Output;
 
+    /// Call the `Func`.
+    ///
+    /// Notice that this does not take a self argument, which in turn means `Func`
+    /// cannot effectively close over a context. This decision trades power for convenience;
+    /// a three-trait `Fn` heirarchy like that in std provides a great deal of power in a
+    /// small fraction of use-cases, but it also comes at great expanse to the other 95% of
+    /// use cases.
     fn call(i: Input) -> Self::Output;
 }
 

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -57,6 +57,7 @@
 //! ```
 
 use indices::{Here, There, Suffixed};
+use traits::{Poly, Func, ToRef, IntoReverse};
 
 use std::ops::Add;
 
@@ -813,21 +814,6 @@ where
     }
 }
 
-/// Trait that allows for reversing a given data structure.
-///
-/// Implemented for HLists.
-///
-/// This functionality is also provided as an [inherent method].
-/// However, you may find this trait useful in generic contexts.
-///
-/// [inherent method]: struct.HCons.html#method.into_reverse
-pub trait IntoReverse {
-    type Output;
-
-    /// Reverses a given data structure.
-    fn into_reverse(self) -> Self::Output;
-}
-
 impl IntoReverse for HNil {
     type Output = HNil;
     fn into_reverse(self) -> Self::Output {
@@ -848,35 +834,6 @@ where
             tail: HNil,
         }
     }
-}
-
-/// Wrapper type around a function for polymorphic maps and folds.
-///
-/// This is a thin generic wrapper type that is used to differentiate
-/// between single-typed generic closures `F` that implements, say, `Fn(i8) -> bool`,
-/// and a Poly-typed `F` that implements multiple Function types, say
-/// `Func<i8, Output=bool>`, `Func<bool, Output=f32>` etc.
-///
-/// This is needed because there are completely generic impls for many of the
-/// HList traits that take a simple unwrapped closure.
-#[derive(Debug, Copy, Clone, Default)]
-pub struct Poly<T>(pub T);
-
-/// This is a simple, user-implementable alternative to `Fn`.
-///
-/// Might not be necessary if/when Fn(Once, Mut) traits are implementable
-/// in stable Rust
-pub trait Func<Input> {
-    type Output;
-
-    /// Call the `Func`.
-    ///
-    /// Notice that this does not take a self argument, which in turn means `Func`
-    /// cannot effectively close over a context. This decision trades power for convenience;
-    /// a three-trait `Fn` heirarchy like that in std provides a great deal of power in a
-    /// small fraction of use-cases, but it also comes at great expanse to the other 95% of
-    /// use cases.
-    fn call(i: Input) -> Self::Output;
 }
 
 impl<P, H, Tail> HMappable<Poly<P>> for HCons<H, Tail>
@@ -1016,29 +973,6 @@ where
         let folded_tail = self.tail.foldr(folder, init);
         (folder)(self.head, folded_tail)
     }
-}
-
-/// An alternative to AsRef that does not force the reference type to be a pointer itself.
-///
-/// This lets us create implementations for our recursive traits that take the resulting
-/// Output reference type, without having to deal with strange, spurious overflows
-/// that sometimes occur when trying to implement a trait for &'a T (see this comment:
-/// https://github.com/lloydmeta/frunk/pull/106#issuecomment-377927198)
-///
-/// This is essentially From, but the more specific nature of it means it's more ergonomic
-/// in actual usage.
-///
-/// Implemented for HLists.
-///
-/// This functionality is also provided as an [inherent method].
-/// However, you may find this trait useful in generic contexts.
-///
-/// [inherent method]: struct.HCons.html#method.to_ref
-pub trait ToRef<'a> {
-    type Output;
-
-    #[inline(always)]
-    fn to_ref(&'a self) -> Self::Output;
 }
 
 impl<'a> ToRef<'a> for HNil {

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -54,7 +54,6 @@
 //! ```
 
 use std::ops::Add;
-use std::marker::PhantomData;
 
 /// Typeclass for HList-y behaviour
 ///
@@ -630,23 +629,8 @@ where
     }
 }
 
-/// Largely lifted from https://github.com/Sgeo/hlist/blob/master/src/lib.rs#L30
-
-/// Used as an index into an `HList`.
-///
-/// `Here` is 0, pointing to the head of the HList.
-///
-/// Users should normally allow type inference to create this type
-#[allow(dead_code)]
-pub enum Here {}
-
-/// Used as an index into an `HList`.
-///
-/// `There<T>` is 1 + `T`.
-///
-/// Users should normally allow type inference to create this type.
-#[allow(dead_code)]
-pub struct There<T>(PhantomData<T>);
+// FIXME kill this one examples are updated
+pub use ::indices::{Here, There, Suffixed};
 
 /// Trait for borrowing an HList element by type
 ///
@@ -1303,9 +1287,6 @@ where
         h_cons(Head::default(), Tail::lift_from(part))
     }
 }
-
-/// An index denoting that `Suffix` is just that.
-pub struct Suffixed<Suffix>(PhantomData<Suffix>);
 
 impl<Prefix, Suffix> LiftFrom<Prefix, Suffixed<Suffix>> for <Prefix as Add<Suffix>>::Output
 where

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -6,7 +6,10 @@
 //! # Examples
 //!
 //! ```
-//! # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+//! #[macro_use]
+//! extern crate frunk;
+//!
+//! # fn main() {
 //! let h = hlist![1, "hi"];
 //! assert_eq!(h.len(), 2);
 //! let (a, b) = h.into_tuple2();
@@ -65,8 +68,10 @@ pub trait HList: Sized {
     ///
     /// # Examples
     /// ```
-    /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::HList; fn main() {
-    /// assert_eq!(<Hlist![i32, bool, f32] as HList>::LEN, 3);
+    /// # #[macro_use] extern crate frunk; fn main() {
+    /// use frunk::prelude::*;
+    ///
+    /// assert_eq!(<Hlist![i32, bool, f32]>::LEN, 3);
     /// # }
     /// ```
     const LEN: usize;
@@ -81,7 +86,7 @@ pub trait HList: Sized {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core; fn main() {
+    /// # #[macro_use] extern crate frunk; fn main() {
     /// let h = hlist![1, "hi"];
     /// assert_eq!(h.len(), 2);
     /// # }
@@ -96,8 +101,10 @@ pub trait HList: Sized {
     ///
     /// # Examples
     /// ```
-    /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::HList; fn main() {
-    /// assert_eq!(<Hlist![i32, bool, f32] as HList>::static_len(), 3);
+    /// # #[macro_use] extern crate frunk; fn main() {
+    /// use frunk::prelude::*;
+    ///
+    /// assert_eq!(<Hlist![i32, bool, f32]>::static_len(), 3);
     /// # }
     /// ```
     #[inline]
@@ -109,7 +116,7 @@ pub trait HList: Sized {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core; fn main() {
+    /// # #[macro_use] extern crate frunk; fn main() {
     /// let h1 = hlist![1, "hi"];
     /// let h2 = h1.prepend(true);
     /// let (a, (b, c)) = h2.into_tuple2();
@@ -169,11 +176,11 @@ impl<H, T> HCons<H, T> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::HNil; fn main() {
+    /// # #[macro_use] extern crate frunk; fn main() {
     /// let h = hlist!("hi");
     /// let (h, tail) = h.pop();
     /// assert_eq!(h, "hi");
-    /// assert_eq!(tail, HNil);
+    /// assert_eq!(tail, hlist![]);
     /// # }
     /// ```
     pub fn pop(self) -> (H, T) {
@@ -188,11 +195,14 @@ impl<H, T> HCons<H, T> {
 /// # Examples
 ///
 /// ```
-/// # use frunk_core::hlist::*;
+/// # extern crate frunk; fn main() {
+/// use frunk::hlist::{HNil, h_cons};
+///
 /// let h_list = h_cons("what", h_cons(1.23f32, HNil));
 /// let (h1, h2) = h_list.into_tuple2();
 /// assert_eq!(h1, "what");
 /// assert_eq!(h2, 1.23f32);
+/// # }
 /// ```
 pub fn h_cons<H, T: HList>(h: H, tail: T) -> HCons<H, T> {
     HCons {
@@ -211,7 +221,7 @@ macro_rules! gen_inherent_methods {
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; fn main() {
+            /// # #[macro_use] extern crate frunk; fn main() {
             /// let h = hlist![1, "hi"];
             /// assert_eq!(h.len(), 2);
             /// # }
@@ -228,7 +238,7 @@ macro_rules! gen_inherent_methods {
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; fn main() {
+            /// # #[macro_use] extern crate frunk; fn main() {
             /// let h1 = hlist![1, "hi"];
             /// let h2 = h1.prepend(true);
             /// let (a, (b, c)) = h2.into_tuple2();
@@ -254,7 +264,7 @@ macro_rules! gen_inherent_methods {
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; fn main() {
+            /// # #[macro_use] extern crate frunk; fn main() {
             /// let h = hlist![9000, "joe", 41f32, true];
             /// let (reshaped, remainder): (Hlist![f32, i32, &str], _) = h.sculpt();
             /// assert_eq!(reshaped, hlist![41f32, 9000, "joe"]);
@@ -273,7 +283,7 @@ macro_rules! gen_inherent_methods {
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; fn main() {
+            /// # #[macro_use] extern crate frunk; fn main() {
             /// assert_eq!(hlist![].into_reverse(), hlist![]);
             ///
             /// assert_eq!(
@@ -295,7 +305,7 @@ macro_rules! gen_inherent_methods {
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; fn main() {
+            /// # #[macro_use] extern crate frunk; fn main() {
             /// assert_eq!(hlist![].to_ref(), hlist![]);
             ///
             /// assert_eq!(hlist![1, true].to_ref(), hlist![&1, &true]);
@@ -323,10 +333,10 @@ macro_rules! gen_inherent_methods {
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
-            /// let nil = HNil;
+            /// # #[macro_use] extern crate frunk; fn main() {
+            /// use ::frunk::HNil;
             ///
-            /// assert_eq!(nil.map(HNil), HNil);
+            /// assert_eq!(HNil.map(HNil), HNil);
             ///
             /// let h = hlist![1, false, 42f32];
             ///
@@ -381,10 +391,10 @@ macro_rules! gen_inherent_methods {
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
-            /// let nil = HNil;
+            /// # #[macro_use] extern crate frunk; fn main() {
+            /// let nil = hlist![];
             ///
-            /// assert_eq!(nil.foldl(HNil, 0), 0);
+            /// assert_eq!(nil.foldl(hlist![], 0), 0);
             ///
             /// let h = hlist![1, false, 42f32];
             ///
@@ -468,10 +478,10 @@ macro_rules! gen_inherent_methods {
             /// # Examples
             ///
             /// ```
-            /// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
-            /// let nil = HNil;
+            /// # #[macro_use] extern crate frunk; fn main() {
+            /// let nil = hlist![];
             ///
-            /// assert_eq!(nil.foldr(HNil, 0), 0);
+            /// assert_eq!(nil.foldr(hlist![], 0), 0);
             ///
             /// let h = hlist![1, false, 42f32];
             ///
@@ -515,7 +525,7 @@ impl<Head, Tail> HCons<Head, Tail> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core; fn main() {
+    /// # #[macro_use] extern crate frunk; fn main() {
     /// let h = hlist![1i32, 2u32, "hello", true, 42f32];
     ///
     /// // Often, type inference can figure out the type you want.
@@ -547,7 +557,7 @@ impl<Head, Tail> HCons<Head, Tail> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core; fn main() {
+    /// # #[macro_use] extern crate frunk; fn main() {
     /// let list = hlist![1, "hello", true, 42f32];
     ///
     /// // Often, type inference can figure out the target type.
@@ -577,7 +587,7 @@ impl<Head, Tail> HCons<Head, Tail> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core; fn main() {
+    /// # #[macro_use] extern crate frunk; fn main() {
     /// let h = hlist![1, "hello", true, 42f32];
     ///
     /// // We now have a much nicer pattern matching experience
@@ -1107,7 +1117,7 @@ where
 /// can handle all cases
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+/// # #[macro_use] extern crate frunk; fn main() {
 /// let h = hlist![1, 2, 3, 4, 5];
 ///
 /// let r: isize = h.foldl(|acc, next| acc + next, 0);
@@ -1219,7 +1229,10 @@ impl<T: Default, Tail: Default + HList> Default for HCons<T, Tail> {
 /// `LiftFrom` is the reciprocal of `LiftInto`.
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+/// # #[macro_use] extern crate frunk; fn main() {
+/// use frunk::lift_from;
+/// use frunk::prelude::*;
+///
 /// type H = Hlist![(), usize, f64, (), bool];
 ///
 /// let x = H::lift_from(42.0);
@@ -1244,7 +1257,9 @@ pub fn lift_from<I, T, PF: LiftFrom<T, I>>(part: T) -> PF {
 /// `LiftInto` is the reciprocal of `LiftFrom`.
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core; use frunk_core::hlist::*; fn main() {
+/// # #[macro_use] extern crate frunk; fn main() {
+/// use frunk::prelude::*;
+///
 /// type H = Hlist![(), usize, f64, (), bool];
 ///
 /// // Type inference works as expected:

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -331,7 +331,7 @@ macro_rules! gen_inherent_methods {
             /// * A single closure (for mapping an HList that is homogenous).
             /// * A single [`Poly`].
             ///
-            /// [`Poly`]: struct.Poly.html
+            /// [`Poly`]: ../traits/struct.Poly.html
             ///
             /// # Examples
             ///
@@ -474,7 +474,6 @@ macro_rules! gen_inherent_methods {
             ///        f1( x1,    f2( x2,    f3( x3, ...   fN( xN, init))...)))
             /// ```
             ///
-            /// [`Poly`]: struct.Poly.html
             /// [`HNil`]: struct.HNil.html
             /// [`h_cons`]: fn.h_cons.html
             ///

--- a/core/src/indices.rs
+++ b/core/src/indices.rs
@@ -1,0 +1,33 @@
+//! Types used for indexing into HLists and coproducts.
+//!
+//! frunk frequently uses phantom index types as a technique to avoid
+//! overlapping impls for some traits.
+//!
+//! Currently, `Index` type parameters in traits are not ever really intended
+//! to be selected by the user, and are instead simply solved for by type
+//! inference wherever the compiler can see that there is a unique solution.
+//! Therefore, you don't really have much of a reason to use the things in this
+//! module.
+//!
+//! **...yet.** `;)`
+
+use std::marker::PhantomData;
+
+// Largely lifted from https://github.com/Sgeo/hlist/blob/master/src/lib.rs#L30
+
+/// Used as an index into an `HList`.
+///
+/// `Here` is 0, pointing to the head of the HList.
+///
+/// Users should normally allow type inference to create this type.
+pub struct Here(());
+
+/// Used as an index into an `HList`.
+///
+/// `There<T>` is 1 + `T`.
+///
+/// Users should normally allow type inference to create this type.
+pub struct There<T>(PhantomData<T>);
+
+/// An index denoting that `Suffix` is just that.
+pub struct Suffixed<Suffix>(PhantomData<Suffix>);

--- a/core/src/indices.rs
+++ b/core/src/indices.rs
@@ -20,14 +20,20 @@ use std::marker::PhantomData;
 /// `Here` is 0, pointing to the head of the HList.
 ///
 /// Users should normally allow type inference to create this type.
-pub struct Here(());
+pub struct Here {
+    _priv: (),
+}
 
 /// Used as an index into an `HList`.
 ///
 /// `There<T>` is 1 + `T`.
 ///
 /// Users should normally allow type inference to create this type.
-pub struct There<T>(PhantomData<T>);
+pub struct There<T> {
+    _marker: PhantomData<T>,
+}
 
 /// An index denoting that `Suffix` is just that.
-pub struct Suffixed<Suffix>(PhantomData<Suffix>);
+pub struct Suffixed<Suffix> {
+    _marker: PhantomData<Suffix>,
+}

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -219,19 +219,53 @@ where
     <B as LabelledGeneric>::transform_from(a)
 }
 
-// Create a bunch of enums that can be used to represent characters on the type level
-macro_rules! create_enums_for {
-    ($($i: ident)*) => {
-        $(
-            #[allow(non_snake_case, non_camel_case_types)]
-            #[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
-            pub enum $i {}
-        )*
+// FIXME kill this once examples have been fixed
+pub use self::chars::*;
+
+pub mod chars {
+    //! Types for building type-level labels from character sequences.
+    //!
+    //! This is designed to be glob-imported:
+    //!
+    // FIXME un-ignore this once examples have been fixed
+    //! ```rust,ignore
+    //! # extern crate frunk;
+    //! # fn main() {
+    //! # #[allow(unused)]
+    //! use frunk::labelled::chars::*;
+    //! # }
+    //! ```
+
+    macro_rules! create_enums_for {
+        ($($i: ident)*) => {
+            $(
+                #[allow(non_snake_case, non_camel_case_types)]
+                #[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
+                pub enum $i {}
+            )*
+        }
+    }
+
+    // Add more as needed.
+    create_enums_for! {
+        // all valid identifier characters
+        a b c d e f g h i j k l m n o p q r s t u v w x y z
+        A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+        _1 _2 _3 _4 _5 _6 _7 _8 _9 _0 __
+    }
+
+    #[test]
+    fn simple_var_names_are_allowed() {
+        // Rust forbids variable bindings that shadow unit structs,
+        // so unit struct characters would cause a lot of trouble.
+        //
+        // Good thing I don't plan on adding reified labels. - Exp
+        let a = 3;
+        match a {
+            a => assert_eq!(a, 3),
+        }
     }
 }
-
-// Add more as needed.
-create_enums_for! { a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D E F G H I J K L M N O P Q R S T U V W X Y Z __ _1 _2 _3 _4 _5 _6 _7 _8 _9 _0 }
 
 /// A Label contains a type-level Name, a runtime value, and
 /// a reference to a `&'static str` name.

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -217,9 +217,6 @@ where
     <B as LabelledGeneric>::transform_from(a)
 }
 
-// FIXME kill this once examples have been fixed
-pub use self::chars::*;
-
 pub mod chars {
     //! Types for building type-level labels from character sequences.
     //!

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -4,7 +4,7 @@
 //! that the generic representation should contain information about field names.
 //!
 //! Having a separate trait for LabelledGenerics gives us the freedom to derive both
-//! lablled and non-labelled generic type class instances for our types.
+//! labelled and non-labelled generic type class instances for our types.
 //!
 //! Asides from the main LabelledGeneric trait, this module holds helper methods that allow
 //! users to use LabelledGeneric without using universal function call syntax.
@@ -14,10 +14,12 @@
 //! # Examples
 //!
 //! ```
-//! # #[macro_use] extern crate frunk_core;
-//! # use frunk_core::labelled::*;
-//! # use frunk_core::hlist::*;
+//! #[macro_use]
+//! extern crate frunk;
+//!
 //! # fn main() {
+//! use frunk::labelled::chars::*;
+//!
 //! // Optionally alias our tuple that represents our type-level string
 //! type name = (n,a,m,e);
 //! let labelled = field![name, "Lloyd"];
@@ -26,16 +28,14 @@
 //! # }
 //! ```
 //!
-//! A more common usage is to use LabelledGeneric to transform strucst that have mis-matched
-//! fields !
+//! A more common usage is to use LabelledGeneric to transform structs that have mismatched
+//! fields!
 //!
 //! ```
-//! # #[allow(unused_imports)]
-//! # #[macro_use] extern crate frunk_derives;
-//! # #[macro_use] extern crate frunk_core;
-//! # use frunk_core::hlist::*; fn main() {
-//! # use frunk_core::hlist::*;
-//! # use frunk_core::labelled::*;
+//! #[macro_use] extern crate frunk;
+//! #[macro_use] extern crate frunk_core; // required when using custom derives
+//!
+//! # fn main() {
 //! #[derive(LabelledGeneric)]
 //! struct NewUser<'a> {
 //!     first_name: &'a str,
@@ -59,7 +59,7 @@
 //!
 //! // transform_from automagically sculpts the labelled generic
 //! // representation of the source object to that of the target type
-//! let s_user: ShortUser = transform_from(n_user); // done
+//! let s_user: ShortUser = frunk::transform_from(n_user); // done
 //! # }
 //! ```
 
@@ -78,12 +78,10 @@ use std::fmt;
 /// # Examples
 ///
 /// ```rust
-/// # #[allow(unused_imports)]
-/// # #[macro_use] extern crate frunk_derives;
-/// # #[macro_use] extern crate frunk_core;
-/// # use frunk_core::hlist::*; fn main() {
-/// use frunk_core::hlist::*;
-/// use frunk_core::labelled::*;
+/// #[macro_use] extern crate frunk;
+/// #[macro_use] extern crate frunk_core;
+///
+/// # fn main() {
 /// #[derive(LabelledGeneric)]
 /// struct NewUser<'a> {
 ///     first_name: &'a str,
@@ -107,7 +105,7 @@ use std::fmt;
 ///
 /// // transform_from automagically sculpts the labelled generic
 /// // representation of the source object to that of the target type
-/// let s_user: SavedUser = transform_from(n_user); // done
+/// let s_user: SavedUser = frunk::transform_from(n_user); // done
 /// # }
 pub trait LabelledGeneric {
     /// The labelled generic representation type
@@ -227,8 +225,7 @@ pub mod chars {
     //!
     //! This is designed to be glob-imported:
     //!
-    // FIXME un-ignore this once examples have been fixed
-    //! ```rust,ignore
+    //! ```rust
     //! # extern crate frunk;
     //! # fn main() {
     //! # #[allow(unused)]
@@ -275,9 +272,9 @@ pub mod chars {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core;
-/// # use frunk_core::labelled::*;
-/// # use frunk_core::hlist::*;
+/// # #[macro_use] extern crate frunk;
+/// use frunk::labelled::chars::*;
+///
 /// # fn main() {
 /// let labelled = field![(n,a,m,e), "joe"];
 /// assert_eq!(labelled.name, "name");
@@ -329,10 +326,14 @@ where
 /// # Examples
 ///
 /// ```
-/// # use frunk_core::labelled::*;
+/// #[macro_use] extern crate frunk; fn main() {
+/// use frunk::labelled::chars::*;
+/// use frunk::labelled::field_with_name;
+///
 /// let l = field_with_name::<(n,a,m,e),_>("name", "joe");
 /// assert_eq!(l.value, "joe");
 /// assert_eq!(l.name, "name");
+/// # }
 /// ```
 pub fn field_with_name<Label, Value>(name: &'static str, value: Value) -> Field<Label, Value> {
     Field {
@@ -353,10 +354,10 @@ pub trait IntoUnlabelled {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core;
-    /// # use frunk_core::labelled::*;
-    /// # use frunk_core::hlist::*;
+    /// # #[macro_use] extern crate frunk;
     /// # fn main() {
+    /// use frunk::labelled::chars::*;
+    /// use frunk::labelled::IntoUnlabelled;
     ///
     /// let labelled_hlist = hlist![
     ///     field!((n, a, m, e), "joe"),
@@ -406,10 +407,10 @@ pub trait IntoValueLabelled {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk_core;
-    /// # use frunk_core::labelled::*;
-    /// # use frunk_core::hlist::*;
+    /// # #[macro_use] extern crate frunk;
     /// # fn main() {
+    /// use frunk::labelled::{ValueField, IntoValueLabelled};
+    /// use frunk::labelled::chars::*;
     ///
     /// let labelled_hlist = hlist![
     ///     field!((n, a, m, e), "joe"),
@@ -462,6 +463,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use super::chars::*;
 
     // Set up some aliases
     #[allow(non_camel_case_types)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -64,6 +64,7 @@ pub mod hlist;
 pub mod coproduct;
 pub mod generic;
 pub mod labelled;
+pub mod indices;
 mod tuples;
 
 #[cfg(test)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -65,6 +65,7 @@ pub mod coproduct;
 pub mod generic;
 pub mod labelled;
 pub mod indices;
+pub mod traits;
 mod tuples;
 
 #[cfg(test)]

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -8,7 +8,7 @@
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core; use ::frunk_core::hlist::*; fn main() {
+/// # #[macro_use] extern crate frunk; fn main() {
 /// let h = hlist![13.5f32, "hello", Some(41)];
 /// let (h1, (h2, h3)) = h.into_tuple2();
 /// assert_eq!(h1, 13.5f32);
@@ -46,7 +46,7 @@ macro_rules! hlist {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core; fn main() {
+/// # #[macro_use] extern crate frunk; fn main() {
 /// let h = hlist![13.5f32, "hello", Some(41)];
 /// let hlist_pat![a1, a2, a3] = h;
 /// assert_eq!(a1, 13.5f32);
@@ -85,7 +85,7 @@ macro_rules! hlist_pat {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core; fn main() {
+/// # #[macro_use] extern crate frunk; fn main() {
 /// let h: Hlist!(f32, &str, Option<i32>) = hlist![13.5f32, "hello", Some(41)];
 ///
 /// // Use "...Tail" to append another HList type at the end.
@@ -110,8 +110,7 @@ macro_rules! Hlist {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core;
-/// # use frunk_core::coproduct::*;
+/// # #[macro_use] extern crate frunk;
 /// # fn main() {
 /// type I32Bool = Coprod!(i32, bool);
 /// let co1 = I32Bool::inject(3);
@@ -142,9 +141,9 @@ macro_rules! Coprod {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core;
-/// # use frunk_core::labelled::*;
-/// # use frunk_core::hlist::*;
+/// # #[macro_use] extern crate frunk;
+/// use frunk::labelled::chars::*;
+
 /// # fn main() {
 /// let labelled = field![(n,a,m,e), "joe"];
 /// assert_eq!(labelled.name, "name");
@@ -157,9 +156,7 @@ macro_rules! Coprod {
 ///   will be set to the stringified version of the type provided.
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core;
-/// # use frunk_core::labelled::*;
-/// # use frunk_core::hlist::*;
+/// # #[macro_use] extern crate frunk;
 /// # fn main() {
 /// enum first_name {}
 /// let labelled = field![first_name, "Joe"];
@@ -172,9 +169,9 @@ macro_rules! Coprod {
 ///   _and_ a custom name, passed as the last argument in the macro
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core;
-/// # use frunk_core::labelled::*;
-/// # use frunk_core::hlist::*;
+/// # #[macro_use] extern crate frunk;
+/// use frunk::labelled::chars::*;
+///
 /// # fn main() {
 /// // useful aliasing of our type-level string
 /// type age = (a, g, e);
@@ -214,8 +211,7 @@ macro_rules! field {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate frunk_core;
-/// # use frunk_core::coproduct::*;
+/// # #[macro_use] extern crate frunk;
 /// # fn main() {
 /// type I32F32StrBool<'a> = Coprod!(i32, f32, &'a str);
 ///
@@ -331,8 +327,8 @@ mod tests {
 
     #[test]
     fn ellipsis_tail() {
+        use coproduct::Coproduct;
         use test_structs::unit_copy::{A, B, C};
-        use coproduct::*;
 
         // hlist: accepted locations, and consistency between macros
         let hlist_pat![...hlist_pat![C]]: Hlist![...Hlist![C]] = { hlist![...hlist![C]] };
@@ -364,7 +360,6 @@ mod tests {
 
     #[test]
     fn poly_fn_macro_test() {
-        use hlist::HMappable;
         let h = hlist![9000, "joe", 41f32, "schmoe", 50];
         let h2 = h.map(poly_fn!(
             |x: i32| -> bool { x > 100 },
@@ -376,8 +371,6 @@ mod tests {
 
     #[test]
     fn poly_fn_macro_coproduct_test() {
-        use coproduct::*;
-
         type I32F32StrBool<'a> = Coprod!(i32, f32, &'a str);
 
         let co1 = I32F32StrBool::inject("lollerskates");
@@ -391,7 +384,6 @@ mod tests {
 
     #[test]
     fn poly_fn_macro_trailing_commas_test() {
-        use hlist::HMappable;
         let h = hlist![9000, "joe", 41f32, "schmoe", 50];
         let h2 = h.map(poly_fn!(
             |x: i32| -> bool { x > 100 },

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -278,20 +278,20 @@ macro_rules! poly_fn {
     (p~ $([$($pars: tt, )*] |$p_args: ident : $p_arg_typ: ty| -> $p_ret_typ: ty { $p_body: expr }, )* ~p f~ $(|$args: ident : $arg_typ: ty| -> $ret_typ: ty { $body: expr }, )* ~f) => {{
         struct F;
         $(
-            impl<$($pars,)*> $crate::hlist::Func<$p_arg_typ> for F {
+            impl<$($pars,)*> $crate::traits::Func<$p_arg_typ> for F {
                 type Output = $p_ret_typ;
 
                 fn call($p_args: $p_arg_typ) -> Self::Output { $p_body }
             }
         )*
         $(
-            impl $crate::hlist::Func<$arg_typ> for F {
+            impl $crate::traits::Func<$arg_typ> for F {
                 type Output = $ret_typ;
 
                 fn call($args: $arg_typ) -> Self::Output { $body }
             }
         )*
-        $crate::hlist::Poly(F)
+        $crate::traits::Poly(F)
     }}
 }
 

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -1,0 +1,67 @@
+//! Traits that provide generic functionality for multiple types in frunk
+
+/// An alternative to AsRef that does not force the reference type to be a pointer itself.
+///
+/// This lets us create implementations for our recursive traits that take the resulting
+/// Output reference type, without having to deal with strange, spurious overflows
+/// that sometimes occur when trying to implement a trait for &'a T (see this comment:
+/// https://github.com/lloydmeta/frunk/pull/106#issuecomment-377927198)
+///
+/// This is essentially From, but the more specific nature of it means it's more ergonomic
+/// in actual usage.
+///
+/// Implemented for HLists.
+///
+/// This functionality is also provided as an [inherent method].
+/// However, you may find this trait useful in generic contexts.
+///
+/// [inherent method]: struct.HCons.html#method.to_ref
+pub trait ToRef<'a> {
+    type Output;
+
+    fn to_ref(&'a self) -> Self::Output;
+}
+
+/// Trait that allows for reversing a given data structure.
+///
+/// Implemented for HLists.
+///
+/// This functionality is also provided as an [inherent method].
+/// However, you may find this trait useful in generic contexts.
+///
+/// [inherent method]: struct.HCons.html#method.into_reverse
+pub trait IntoReverse {
+    type Output;
+
+    /// Reverses a given data structure.
+    fn into_reverse(self) -> Self::Output;
+}
+
+/// Wrapper type around a function for polymorphic maps and folds.
+///
+/// This is a thin generic wrapper type that is used to differentiate
+/// between single-typed generic closures `F` that implements, say, `Fn(i8) -> bool`,
+/// and a Poly-typed `F` that implements multiple Function types, say
+/// `Func<i8, Output=bool>`, `Func<bool, Output=f32>` etc.
+///
+/// This is needed because there are completely generic impls for many of the
+/// HList traits that take a simple unwrapped closure.
+#[derive(Debug, Copy, Clone, Default)]
+pub struct Poly<T>(pub T);
+
+/// This is a simple, user-implementable alternative to `Fn`.
+///
+/// Might not be necessary if/when Fn(Once, Mut) traits are implementable
+/// in stable Rust
+pub trait Func<Input> {
+    type Output;
+
+    /// Call the `Func`.
+    ///
+    /// Notice that this does not take a self argument, which in turn means `Func`
+    /// cannot effectively close over a context. This decision trades power for convenience;
+    /// a three-trait `Fn` heirarchy like that in std provides a great deal of power in a
+    /// small fraction of use-cases, but it also comes at great expanse to the other 95% of
+    /// use cases.
+    fn call(i: Input) -> Self::Output;
+}

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -7,15 +7,11 @@
 /// that sometimes occur when trying to implement a trait for &'a T (see this comment:
 /// https://github.com/lloydmeta/frunk/pull/106#issuecomment-377927198)
 ///
-/// This is essentially From, but the more specific nature of it means it's more ergonomic
-/// in actual usage.
-///
-/// Implemented for HLists.
-///
-/// This functionality is also provided as an [inherent method].
+/// This functionality is also provided as an inherent method [on HLists] and [on Coproducts].
 /// However, you may find this trait useful in generic contexts.
 ///
-/// [inherent method]: struct.HCons.html#method.to_ref
+/// [on HLists]: ../hlist/struct.HCons.html#method.to_ref
+/// [on Coproducts]: ../coproduct/enum.Coproduct.html#method.to_ref
 pub trait ToRef<'a> {
     type Output;
 
@@ -29,7 +25,7 @@ pub trait ToRef<'a> {
 /// This functionality is also provided as an [inherent method].
 /// However, you may find this trait useful in generic contexts.
 ///
-/// [inherent method]: struct.HCons.html#method.into_reverse
+/// [inherent method]: ../hlist/struct.HCons.html#method.into_reverse
 pub trait IntoReverse {
     type Output;
 
@@ -41,11 +37,13 @@ pub trait IntoReverse {
 ///
 /// This is a thin generic wrapper type that is used to differentiate
 /// between single-typed generic closures `F` that implements, say, `Fn(i8) -> bool`,
-/// and a Poly-typed `F` that implements multiple Function types, say
-/// `Func<i8, Output=bool>`, `Func<bool, Output=f32>` etc.
+/// and a Poly-typed `F` that implements multiple Function types
+/// via the [`Func`] trait. (say, `Func<i8, Output=bool>` and `Func<bool, Output=f32>`)
 ///
 /// This is needed because there are completely generic impls for many of the
 /// HList traits that take a simple unwrapped closure.
+///
+/// [`Func`]: trait.Func.html
 #[derive(Debug, Copy, Clone, Default)]
 pub struct Poly<T>(pub T);
 

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -4,7 +4,12 @@ use syn::{Ident, Data, Fields, FieldsNamed, Field};
 use proc_macro::TokenStream;
 
 /// These are assumed to exist as enums in frunk_core::labelled
-const ALPHA_CHARS: &'static [char] = &['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'];
+const ALPHA_CHARS: &'static [char] = &[
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+];
 
 /// These are assumed to exist as enums in frunk_core::labelled as underscore prepended enums
 const UNDERSCORE_CHARS: &'static [char] = &['_', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
@@ -96,7 +101,7 @@ fn build_type_level_name_for(ident: &Ident) -> Tokens {
     let name = ident.as_ref();
     let name_as_idents: Vec<Ident> = name.chars().flat_map(|c| encode_as_ident(&c)).collect();
     let name_as_tokens: Vec<Tokens> = name_as_idents.iter().map(|ident| {
-        quote! { ::frunk_core::labelled::#ident }
+        quote! { ::frunk_core::labelled::chars::#ident }
     }).collect();
     quote! { (#(#name_as_tokens),*) }
 }

--- a/examples/generic.rs
+++ b/examples/generic.rs
@@ -1,7 +1,6 @@
 #[macro_use] // for the hlist macro
 extern crate frunk;
 extern crate frunk_core;
-use frunk::generic::*; // for the Generic trait and HList
 
 #[derive(Generic, Debug, PartialEq)]
 struct Person<'a> {
@@ -12,7 +11,7 @@ struct Person<'a> {
 
 fn main() {
     let h = hlist!("Joe", "Blow", 30);
-    let p: Person = from_generic(h);
+    let p: Person = frunk::from_generic(h);
     assert_eq!(
         p,
         Person {

--- a/examples/labelled.rs
+++ b/examples/labelled.rs
@@ -1,7 +1,6 @@
 #[macro_use] // for the hlist macro
 extern crate frunk;
 extern crate frunk_core;
-use frunk::labelled::*; // for the Generic trait and HList
 
 #[derive(LabelledGeneric)]
 struct NewUser<'a> {
@@ -31,13 +30,13 @@ fn main() {
         age: 30,
     };
 
-    let s_user: SavedUser = labelled_convert_from(n_user);
+    let s_user: SavedUser = frunk::labelled_convert_from(n_user);
 
     assert_eq!(s_user.first_name, "Joe");
     assert_eq!(s_user.last_name, "Blow");
     assert_eq!(s_user.age, 30);
 
-    let d_user: DeletedUser = transform_from(s_user);
+    let d_user: DeletedUser = frunk::transform_from(s_user);
 
     assert_eq!(d_user.first_name, "Joe");
     println!("{}", d_user.last_name);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,18 +179,9 @@ pub mod prelude {
     #[doc(no_inline)]
     pub use hlist::HList; // for LEN
     #[doc(no_inline)]
-    pub use hlist::HMappable;
-    #[doc(no_inline)]
-    pub use hlist::HFoldRightable;
-    #[doc(no_inline)]
-    pub use hlist::HFoldLeftable;
-    #[doc(no_inline)]
     pub use hlist::LiftFrom;
     #[doc(no_inline)]
     pub use hlist::LiftInto;
-
-    #[doc(no_inline)]
-    pub use coproduct::CoproductFoldable;
 
     #[doc(no_inline)]
     pub use validated::IntoValidated;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,12 @@ pub use hlist::HNil;
 pub use hlist::HCons;
 #[doc(no_inline)]
 pub use hlist::lift_from;
+#[doc(no_inline)]
+pub use hlist::Poly;
+#[doc(no_inline)]
+pub use hlist::Func;
+#[doc(no_inline)]
+pub use hlist::ToRef; // useful for where bounds
 
 #[doc(no_inline)]
 pub use coproduct::Coproduct;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,11 +138,11 @@ pub use hlist::HCons;
 #[doc(no_inline)]
 pub use hlist::lift_from;
 #[doc(no_inline)]
-pub use hlist::Poly;
+pub use traits::Poly;
 #[doc(no_inline)]
-pub use hlist::Func;
+pub use traits::Func;
 #[doc(no_inline)]
-pub use hlist::ToRef; // useful for where bounds
+pub use traits::ToRef; // useful for where bounds
 
 #[doc(no_inline)]
 pub use coproduct::Coproduct;

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -9,11 +9,12 @@
 //! # Examples
 //!
 //! ```
-//! # use frunk::monoid::*;
-//! # use std::collections::*;
+//! use std::collections::HashMap;
+//! use frunk::{monoid, Monoid};
+//!
 //! let vec_of_no_hashmaps: Vec<HashMap<i32, String>> = Vec::new();
-//! assert_eq!(combine_all(&vec_of_no_hashmaps),
-//!                    <HashMap<i32, String> as Monoid>::empty());
+//! assert_eq!(monoid::combine_all(&vec_of_no_hashmaps),
+//!            <HashMap<i32, String> as Monoid>::empty());
 //!
 //! let mut h1: HashMap<i32, String> = HashMap::new();
 //! h1.insert(1, String::from("Hello"));  // h1 is HashMap( 1 -> "Hello")
@@ -27,8 +28,9 @@
 //! let mut h_expected: HashMap<i32, String> = HashMap::new();
 //! h_expected.insert(1, String::from("Hello World"));
 //! h_expected.insert(2, String::from("Goodbye"));
-//! h_expected.insert(3, String::from("Cruel World")); // h_expected is HashMap ( 1 -> "Hello World", 2 -> "Goodbye", 3 -> "Cruel World")
-//! assert_eq!(combine_all(&vec_of_hashes), h_expected);
+//! h_expected.insert(3, String::from("Cruel World"));
+//! // h_expected is HashMap ( 1 -> "Hello World", 2 -> "Goodbye", 3 -> "Cruel World")
+//! assert_eq!(monoid::combine_all(&vec_of_hashes), h_expected);
 //! ```
 use super::semigroup::{All, Any, Product, Semigroup};
 use std::collections::*;
@@ -41,7 +43,7 @@ pub trait Monoid: Semigroup {
     /// # Examples
     ///
     /// ```
-    /// # use frunk::monoid::*;
+    /// use frunk::Monoid;
     ///
     /// assert_eq!(<i16 as Monoid>::empty(), 0);
     /// ```
@@ -53,9 +55,9 @@ pub trait Monoid: Semigroup {
 /// # Examples
 ///
 /// ```
-/// # use frunk::monoid::*;
+/// use frunk::monoid;
 ///
-/// assert_eq!(combine_n(&Some(2), 4), Some(8));
+/// assert_eq!(monoid::combine_n(&Some(2), 4), Some(8));
 /// ```
 pub fn combine_n<T>(o: &T, times: u32) -> T
 where
@@ -73,7 +75,7 @@ where
 /// # Examples
 ///
 /// ```
-/// # use frunk::monoid::*;
+/// use frunk::monoid::combine_all;
 ///
 /// assert_eq!(combine_all(&vec![Some(1), Some(3)]), Some(4));
 ///

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -5,11 +5,12 @@
 //! # Examples
 //!
 //! ```
-//! # #[macro_use] extern crate frunk;
-//! # #[macro_use] extern crate frunk_core;
-//! # use frunk_core::hlist::*; fn main() {
-//! use frunk_core::hlist::*;
-//! use frunk::semigroup::*;
+//! #[macro_use]
+//! extern crate frunk;
+//!
+//! # fn main() {
+//! use frunk::Semigroup;
+//!
 //! let t1 = (1, 2.5f32, String::from("hi"), Some(3));
 //! let t2 = (1, 2.5f32, String::from(" world"), None);
 //!
@@ -62,7 +63,8 @@ pub trait Semigroup {
     /// # Examples
     ///
     /// ```
-    /// # use frunk::semigroup::*;
+    /// use frunk::Semigroup;
+    ///
     /// assert_eq!(Some(1).combine(&Some(2)), Some(3))
     /// ```
     fn combine(&self, other: &Self) -> Self;
@@ -105,7 +107,8 @@ where
 /// # Examples
 ///
 /// ```
-/// # use frunk::semigroup::*;
+/// use frunk::semigroup::combine_all_option;
+///
 /// let v1 = &vec![1, 2, 3];
 /// assert_eq!(combine_all_option(v1), Some(6));
 ///

--- a/src/validated.rs
+++ b/src/validated.rs
@@ -8,11 +8,13 @@
 //! # Examples
 //!
 //! ```
-//! # #[macro_use] extern crate frunk;
-//! # #[macro_use] extern crate frunk_core;
-//! # use frunk_core::hlist::*;
-//! # use frunk::validated::*;
+//! #[macro_use]
+//! extern crate frunk;
+//!
 //! # fn main() {
+//! use frunk::Validated;
+//! use frunk::prelude::*; // for .into_validated()
+//!
 //! #[derive(PartialEq, Eq, Debug)]
 //! struct Person {
 //!     age: i32,
@@ -67,7 +69,9 @@ where
     /// # Examples
     ///
     /// ```
-    /// # use frunk::validated::*;
+    /// use frunk::Validated;
+    /// use frunk::prelude::*;
+    ///
     /// let r1: Result<String, String> = Result::Ok(String::from("hello"));
     /// let v = r1.into_validated();
     /// assert!(v.is_ok());
@@ -84,7 +88,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// # use frunk::validated::*;
+    /// use frunk::prelude::*;
+    ///
     /// let r1: Result<String, i32> = Result::Err(32);
     /// let v = r1.into_validated();
     /// assert!(v.is_err());
@@ -101,10 +106,11 @@ where
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate frunk;
-    /// # #[macro_use] extern crate frunk_core;
-    /// # use frunk_core::hlist::*;
-    /// # use frunk::validated::*;
+    /// #[macro_use] extern crate frunk;
+    ///
+    /// use frunk::Validated;
+    /// use frunk::prelude::*;
+    ///
     /// # fn main() {
     /// #[derive(PartialEq, Eq, Debug)]
     /// struct Person {
@@ -150,7 +156,8 @@ pub trait IntoValidated<T, E> {
     /// # Examples
     ///
     /// ```
-    /// # use frunk::validated::*;
+    /// use frunk::prelude::*; // IntoValidated is in the prelude
+    ///
     /// let r1: Result<String, i32> = Result::Err(32);
     /// let v = r1.into_validated();
     /// assert!(v.is_err());
@@ -176,10 +183,10 @@ impl<T, E> IntoValidated<T, E> for Result<T, E> {
 ///
 /// ```
 /// # #[macro_use] extern crate frunk;
-/// # #[macro_use] extern crate frunk_core;
-/// # use frunk_core::hlist::*;
-/// # use frunk::validated::*;
 /// # fn main() {
+/// use frunk::Validated;
+/// use frunk::prelude::*;
+///
 /// let r1: Result<String, String> = Result::Ok(String::from("hello"));
 /// let r2: Result<i32, String> = Result::Ok(1);
 /// let v = r1.into_validated() + r2;
@@ -206,10 +213,10 @@ where
 ///
 /// ```
 /// # #[macro_use] extern crate frunk;
-/// # #[macro_use] extern crate frunk_core;
-/// # use frunk_core::hlist::*;
-/// # use frunk::validated::*;
 /// # fn main() {
+/// use frunk::Validated;
+/// use frunk::prelude::*;
+///
 /// let r1: Result<String, String> = Result::Ok(String::from("hello"));
 /// let r2: Result<i32, String> = Result::Ok(1);
 /// let v1 = r1.into_validated();

--- a/tests/coproduct_tests.rs
+++ b/tests/coproduct_tests.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate frunk;
 
-use frunk::coproduct::*;
-
 #[test]
 fn test_inject_coproduct() {
     type I32StrBool = Coprod!(i32, &'static str, bool);
@@ -35,7 +33,7 @@ fn test_coproduct_fold_non_consuming() {
     let co = I32StrBool::inject(true);
 
     assert_eq!(
-        co.as_ref().fold(hlist![
+        co.to_ref().fold(hlist![
             |&i| format!("int {}", i),
             |&f| format!("float {}", f),
             |&b| (if b { "t" } else { "f" }).to_string(),

--- a/tests/generic_tests.rs
+++ b/tests/generic_tests.rs
@@ -2,7 +2,7 @@ extern crate frunk;
 #[macro_use] // for the hlist macro
 extern crate frunk_core;
 
-use frunk::generic::*;
+use frunk::{from_generic, into_generic, convert_from};
 
 mod common;
 use common::*;
@@ -46,7 +46,7 @@ fn test_struct_conversion() {
         last_name: "Cannon",
         age: 3,
     };
-    let pres = <President as Generic>::convert_from(a);
+    let pres: President = frunk::convert_from(a);
     assert_eq!(
         pres,
         President {
@@ -65,8 +65,8 @@ fn test_struct_conversion_round_trip() {
         age: 3,
     };
     let before = a.clone();
-    let p: President = <President as Generic>::convert_from(a);
-    let a_again = <Strategist as Generic>::convert_from(p);
+    let p: President = convert_from(a);
+    let a_again: Strategist = convert_from(p);
     assert_eq!(a_again, before)
 }
 
@@ -83,8 +83,8 @@ fn test_mixed_conversions_round_trip() {
         age: 3,
     };
     let before = u.clone();
-    let au = <ApiUser as Generic>::convert_from(u);
+    let au: ApiUser = convert_from(u);
     // let au2 = <ApiUser as LabelledGeneric>::convert_from(u); <-- will fail at compile time
-    let u_again = <SavedUser as Generic>::convert_from(au);
+    let u_again: SavedUser = convert_from(au);
     assert_eq!(u_again, before)
 }

--- a/tests/labelled_tests.rs
+++ b/tests/labelled_tests.rs
@@ -3,8 +3,11 @@ extern crate frunk;
 extern crate frunk_core;
 extern crate time; //Time library
 
-use frunk::hlist::*;
-use frunk::labelled::*;
+use frunk::{HCons, LabelledGeneric};
+use frunk::{into_labelled_generic, from_labelled_generic, transform_from};
+use frunk::hlist::Sculptor;
+use frunk::labelled::Field;
+use frunk::labelled::chars::*;
 
 mod common;
 

--- a/tests/validated_tests.rs
+++ b/tests/validated_tests.rs
@@ -1,8 +1,7 @@
 extern crate frunk;
 extern crate frunk_core;
 
-use frunk::generic::*; // for the Generic trait and HList
-use frunk::validated::*;
+use frunk::prelude::*;
 
 mod common;
 use common::*;
@@ -40,7 +39,7 @@ fn get_age(yah_nah: YahNah) -> Result<usize, Nope> {
 #[test]
 fn test_to_result_ok() {
     let v = get_name(YahNah::Yah).into_validated() + get_name(YahNah::Yah) + get_age(YahNah::Yah);
-    let person: Result<Person, _> = v.into_result().map(|h| from_generic(h)); // much simpler
+    let person: Result<Person, _> = v.into_result().map(|h| frunk::from_generic(h)); // much simpler
     assert_eq!(
         person.unwrap(),
         Person {


### PR DESCRIPTION
As before, I tried to break this up into individually readible commits.

It includes several of the last-minute breaking changes [mentioned here](https://github.com/lloydmeta/frunk/issues/101#issuecomment-379569647), each as its own commit (or two) near the beginning. This is followed by one really big commit that corrects all of the examples and tests to use the new use paths.

Closes #101 