### PR TITLE
Add [workspace] declaration to root Cargo.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
     travis-cargo build &&
     travis-cargo build -- --example generic &&
     travis-cargo build -- --example labelled &&
-    travis-cargo test -- --all &&
+    travis-cargo test -- --all --no-fail-fast &&
     travis-cargo doc
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,8 @@ script:
     travis-cargo build &&
     travis-cargo build -- --example generic &&
     travis-cargo build -- --example labelled &&
-    travis-cargo test &&
-    cd ${TRAVIS_BUILD_DIR}/core && travis-cargo test &&
-    cd ${TRAVIS_BUILD_DIR}/laws && travis-cargo test &&
-    cd ${TRAVIS_BUILD_DIR} && travis-cargo doc
+    travis-cargo test -- --all &&
+    travis-cargo doc
 
 after_success:
   - travis-cargo doc-upload

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,10 @@ lto = false
 debug-assertions = false
 codegen-units = 1
 panic = 'abort'
+
+[workspace]
+members = [
+    "core",
+    "derives",
+    "laws"
+]


### PR DESCRIPTION
The goal is to simplify testing (e.g. `cargo test --all`)