### PR TITLE
[DEBUG] Try fixing nightly compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ debug = false
 rpath = false
 lto = false
 debug-assertions = false
-codegen-units = 1
+# codegen-units = 1 https://users.rust-lang.org/t/odd-benchmark-results-compiler-optimisation-wall/10503
 
 [workspace]
 members = [

--- a/travis-after-success
+++ b/travis-after-success
@@ -9,10 +9,10 @@ if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != "master" ] && [ "$TRAVIS
     cd  "${TRAVIS_REPO_SLUG}-bench" && \
     # Bench master
     git checkout master && \
-    cargo bench > "${TRAVIS_BUILD_DIR}/benches-control" && \
+    travis_wait cargo bench > "${TRAVIS_BUILD_DIR}/benches-control" && \
     # Bench variable
     cd ${TRAVIS_BUILD_DIR} && \
-    cargo bench > benches-variable && \
+    travis_wait cargo bench > benches-variable && \
     cargo install cargo-benchcmp --force && \
     cargo benchcmp benches-control benches-variable;
 fi


### PR DESCRIPTION
Try disabling `codegen-units = 1` to speed up benches.

This is probably timing out now because of the massively-nested bench that came in via #124 