### PR TITLE
Adds FuncMut and PolyMut, which parallel Func and Poly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]:
 - Added `ToMut` trait, which allows borrowing mutably from a Coproduct or HList.
+- Added `FuncMut` and `PolyMut`, which parallel `Func` and `Poly`.
 
 ## [0.2.2] - 2018-10-21
 - Added support for [transmogrifying (recursively sculpting)](https://docs.rs/frunk/0.2.2/frunk/labelled/trait.Transmogrifier.html) one data type into another

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -58,6 +58,13 @@ pub trait IntoReverse {
 #[derive(Debug, Copy, Clone, Default)]
 pub struct Poly<T>(pub T);
 
+/// A wrapper like [`Poly`] for [`FuncMut`].
+///
+/// [`FuncMut`]: trait.FuncMut.html
+/// [`Poly`]: trait.Poly.html
+#[derive(Debug, Copy, Clone, Default)]
+pub struct PolyMut<T>(pub T);
+
 /// This is a simple, user-implementable alternative to `Fn`.
 ///
 /// Might not be necessary if/when Fn(Once, Mut) traits are implementable
@@ -73,4 +80,14 @@ pub trait Func<Input> {
     /// small fraction of use-cases, but it also comes at great expanse to the other 95% of
     /// use cases.
     fn call(i: Input) -> Self::Output;
+}
+
+/// This is a user-implementable alternative to `FnMut`.
+///
+/// Not necessary if/when the FnMut trait is implementable in stable Rust.
+pub trait FuncMut<Input> {
+    type Output;
+
+    /// Call the `FuncMut`.
+    fn call(&mut self, i: Input) -> Self::Output;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,9 +238,9 @@ pub use hlist::HCons;
 #[doc(no_inline)]
 pub use hlist::HNil;
 #[doc(no_inline)]
-pub use traits::Func;
+pub use traits::{Func, FuncMut};
 #[doc(no_inline)]
-pub use traits::Poly;
+pub use traits::{Poly, PolyMut};
 #[doc(no_inline)]
 pub use traits::{ToMut, ToRef}; // useful for where bounds
 


### PR DESCRIPTION
This also makes `HMappable<F>` accept `FnMut` instead of just `Fn`; I don't believe this would be breaking, but I can split it out if it is.