### PR TITLE
Allow transmogrifying through Vec

### DIFF
--- a/core/src/indices.rs
+++ b/core/src/indices.rs
@@ -53,3 +53,7 @@ pub struct LabelledGenericTransmogIndicesWrapper<T>(PhantomData<T>);
 
 /// Index type wrapper for transmogrifying a generic plucked Source to a generic Target
 pub struct PluckedLabelledGenericIndicesWrapper<T>(T);
+
+/// Index type wrapper for transmogrifying through a (known) container (e.g. `Vec`).
+pub struct MappingIndicesWrapper<T>(PhantomData<(T)>);
+

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -690,6 +690,18 @@ pub trait Transmogrifier<Target, TransmogrifyIndexIndices> {
     fn transmogrify(self) -> Target;
 }
 
+pub struct MappingIndicesWrapper<T>(PhantomData<(T)>);
+
+impl<Key, Source, Target, InnerIndices>
+    Transmogrifier<Vec<Target>, MappingIndicesWrapper<InnerIndices>> for Field<Key, Vec<Source>>
+where
+    Source: Transmogrifier<Target, InnerIndices>
+{
+    fn transmogrify(self) -> Vec<Target> {
+        self.value.into_iter().map(|e| e.transmogrify()).collect()
+    }
+}
+
 /// Implementation of `Transmogrifier` for identity plucked `Field` to `Field` Transforms.
 impl<Key, SourceValue> Transmogrifier<SourceValue, IdentityTransMog> for Field<Key, SourceValue> {
     #[inline(always)]

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -690,8 +690,16 @@ pub trait Transmogrifier<Target, TransmogrifyIndexIndices> {
     fn transmogrify(self) -> Target;
 }
 
-pub struct MappingIndicesWrapper<T>(PhantomData<(T)>);
+/// Implementation of `Transmogrifier` for identity plucked `Field` to `Field` Transforms.
+impl<Key, SourceValue> Transmogrifier<SourceValue, IdentityTransMog> for Field<Key, SourceValue> {
+    #[inline(always)]
+    fn transmogrify(self) -> SourceValue {
+        self.value
+    }
+}
 
+/// Implementation of `Transmogrifier` that maps over a `Vec` in a `Field`, transmogrifying the
+/// elements on the way past.
 impl<Key, Source, Target, InnerIndices>
     Transmogrifier<Vec<Target>, MappingIndicesWrapper<InnerIndices>> for Field<Key, Vec<Source>>
 where
@@ -699,14 +707,6 @@ where
 {
     fn transmogrify(self) -> Vec<Target> {
         self.value.into_iter().map(|e| e.transmogrify()).collect()
-    }
-}
-
-/// Implementation of `Transmogrifier` for identity plucked `Field` to `Field` Transforms.
-impl<Key, SourceValue> Transmogrifier<SourceValue, IdentityTransMog> for Field<Key, SourceValue> {
-    #[inline(always)]
-    fn transmogrify(self) -> SourceValue {
-        self.value
     }
 }
 
@@ -985,6 +985,35 @@ mod tests {
         assert_eq!(
             target,
             hlist![field!(name, "joe"), field!(age, 32), field!(is_admin, true)]
+        )
+    }
+
+    #[test]
+    fn test_transmogrify_through_containers() {
+        type SourceOuter = Hlist![
+            Field<name, &'static str>,
+            Field<inner, Vec<SourceInner>>,
+        ];
+        type SourceInner = Hlist![
+            Field<is_admin, bool>,
+            Field<age, i32>,
+        ];
+        type TargetOuter = Hlist![
+            Field<name, &'static str>,
+            Field<inner, Vec<TargetInner>>,
+        ];
+        type TargetInner = Hlist![
+            Field<age, i32>,
+            Field<is_admin, bool>,
+        ];
+        let child: SourceInner = hlist![field!(is_admin, true), field!(age, 14)];
+        let source: SourceOuter = hlist![field!(name, "Joe"), field!(inner, vec![child])];
+
+        let target: TargetOuter = source.transmogrify();
+        let expected_inner: TargetInner = hlist![field!(age, 14), field!(is_admin, true)];
+        assert_eq!(
+            target,
+            hlist![field!(name, "Joe"), field!(inner, vec![expected_inner])]
         )
     }
 


### PR DESCRIPTION
This is more a proof of concept than a fully fledged PR, but I wanted to get feedback early before wandering down a garden path of pain.

This PR specifically allows conversions of the form:

```
#[derive(Debug, frunk_derives::LabelledGeneric)]
struct Foo {
    bar: Vec<Bar>,
}

#[derive(Debug, frunk_derives::LabelledGeneric)]
struct Foo2 {
    bar: Vec<Bar2>,
}

#[derive(Debug, frunk_derives::LabelledGeneric)]
struct Bar {
    name: String,
}

#[derive(Debug, frunk_derives::LabelledGeneric)]
struct Bar2 {
    name: String
}

fn main() {
    let foo = Foo {
        bar: vec![
            Bar { "Sarah".to_string() },
        ]}
    };
    let foo2: Foo2 = foo.transmogrify();
    println!("{:?}", foo2);
}
```

Limitations:

* Only supports `Vec` (though other stdlib types would be easy to add)
* Only supports `Vec -> Vec`, not (e.g.) `Vec -> List` or similar (maybe judicious use of `FromIterator`?)

Does this look useful/sensible?  Have I missed anything in the implementation?