### PR TITLE
Add support for labelling TupleStructs by index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]:
 - Added `ToMut` trait, which allows borrowing mutably from a Coproduct or HList.
+- Allow `#[derive(LabelledGeneric)]` on tuple structs
 
 ## [0.2.2] - 2018-10-21
 - Added support for [transmogrifying (recursively sculpting)](https://docs.rs/frunk/0.2.2/frunk/labelled/trait.Transmogrifier.html) one data type into another

--- a/derives/src/derive_generic.rs
+++ b/derives/src/derive_generic.rs
@@ -28,7 +28,8 @@ pub fn impl_generic(input: TokenStream) -> impl ToTokens {
             f.ident
                 .clone()
                 .unwrap_or(call_site_ident(&format!("_{}", i)))
-        }).collect();
+        })
+        .collect();
     let hcons_constr = build_hcons_constr(&fnames);
     let hcons_pat = build_hcons_constr(&fnames);
     let new_struct_constr = build_new_struct_constr(name, &fnames, is_tuple_struct);

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -1,7 +1,8 @@
 use common::{build_hcons_constr, call_site_ident, to_ast};
 use proc_macro::TokenStream;
 use quote::ToTokens;
-use syn::{Data, Field, Fields, FieldsNamed, Ident};
+use syn::spanned::Spanned;
+use syn::{Data, Field, Fields, FieldsUnnamed, Ident};
 
 /// These are assumed to exist as enums in frunk_core::labelled
 const ALPHA_CHARS: &'static [char] = &[
@@ -13,6 +14,12 @@ const ALPHA_CHARS: &'static [char] = &[
 /// These are assumed to exist as enums in frunk_core::labelled as underscore prepended enums
 const UNDERSCORE_CHARS: &'static [char] = &['_', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
 
+enum StructType {
+    Named,
+    Tuple,
+}
+use self::StructType::*;
+
 /// Given an AST, returns an implementation of Generic using HList with
 /// Field (see frunk_core::labelled) elements
 ///
@@ -22,28 +29,36 @@ pub fn impl_labelled_generic(input: TokenStream) -> impl ToTokens {
     let name = &ast.ident;
     let generics = &ast.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let fields_named: &FieldsNamed = match ast.data {
-        Data::Struct(ref data) => {
-            match data.fields {
-                Fields::Named(ref fields_named) => fields_named,
-                _ => panic!("Only Structs are supported. Tuple structs cannot be turned into Labelled Generics.")
-            }
+    let (struct_type, fields): (StructType, Vec<Field>) = match ast.data {
+        Data::Struct(ref data) => match data.fields {
+            Fields::Named(ref fields) => (Named, fields.named.iter().cloned().collect()),
+            Fields::Unnamed(ref fields) => (Tuple, create_indexed_fields(fields)),
+            Fields::Unit => panic!("Unit structs cannot be turned into Labelled Generics"),
         },
-        _ => panic!("Only Structs are supported. Tuple structs cannot be turned into Labelled Generics.")
+        _ => panic!(
+            "Only Structs are supported. Enums/Unions cannot be turned into Labelled Generics."
+        ),
     };
-    let fields: Vec<Field> = fields_named.named.iter().map(|f| f.clone()).collect();
-    let repr_type = build_labelled_repr(&fields);
 
+    let repr_type = build_labelled_repr(&fields);
     let fnames: Vec<Ident> = fields
         .iter()
-        // it's impossible to not have idents because we're sure this isn't a tuple struct
+        // it's impossible to not have idents because we create synthetic names for tuple structs
         .map(|f| f.ident.clone().unwrap())
         .collect();
 
     let hcons_constr = build_labelled_hcons_constr(&fields);
     let hcons_pat = build_hcons_constr(&fnames);
-    let new_struct_constr = build_new_labelled_struct_constr(name, &fnames);
-    let struct_deconstr = quote! { #name { #(#fnames, )* } };
+    let (constructor, deconstructor) = match struct_type {
+        Tuple => (
+            build_new_labelled_tuple_struct_constr(name, &fnames),
+            quote! { #name ( #(#fnames, )* ) },
+        ),
+        Named => (
+            build_new_labelled_struct_constr(name, &fnames),
+            quote! { #name { #(#fnames, )* } },
+        ),
+    };
 
     quote! {
         #[allow(non_snake_case, non_camel_case_types)]
@@ -52,16 +67,30 @@ pub fn impl_labelled_generic(input: TokenStream) -> impl ToTokens {
             type Repr = #repr_type;
 
             fn into(self) -> Self::Repr {
-                let #struct_deconstr = self;
+                let #deconstructor = self;
                 #hcons_constr
             }
 
             fn from(r: Self::Repr) -> Self {
                 let #hcons_pat = r;
-                #new_struct_constr
+                #constructor
             }
         }
     }
+}
+
+/// Create synthetic names for tuple struct members
+fn create_indexed_fields(fields: &FieldsUnnamed) -> Vec<Field> {
+    fields
+        .unnamed
+        .iter()
+        .enumerate()
+        .map(|(i, f)| {
+            let mut f = f.clone();
+            f.ident = Some(Ident::new(&format!("_{}", i), f.span()));
+            f
+        })
+        .collect()
 }
 
 /// Builds the labelled HList representation for a vector of fields
@@ -104,7 +133,8 @@ fn build_type_level_name_for(ident: &Ident) -> impl ToTokens {
         .iter()
         .map(|ident| {
             quote! { ::frunk_core::labelled::chars::#ident }
-        }).collect();
+        })
+        .collect();
     quote! { (#(#name_as_tokens),*) }
 }
 
@@ -185,9 +215,27 @@ fn build_field_constr_for(field: &Field) -> impl ToTokens {
 /// Assumes that there are bindings in the immediate environment with those names that
 /// are bound to Field values.
 ///
-/// The opposite of build_labelled_hcons_constr
-fn build_new_labelled_struct_constr(struct_name: &Ident, bindnames: &Vec<Ident>) -> impl ToTokens {
+/// The opposite of build_labelled_hcons_constr for named structs
+fn build_new_labelled_struct_constr(
+    struct_name: &Ident,
+    bindnames: &Vec<Ident>,
+) -> Box<dyn ToTokens> {
     let cloned_bind1 = bindnames.clone();
     let cloned_bind2 = bindnames.clone();
-    quote! { #struct_name { #(#cloned_bind1: #cloned_bind2.value),* } }
+    Box::new(quote! { #struct_name { #(#cloned_bind1: #cloned_bind2.value),* } })
+}
+
+/// Given a tuple struct name, and a number of Idents that act as accessors
+/// names, returns an AST representing how to construct said tuple struct.
+///
+/// Assumes that there are bindings in the immediate environment with those names that
+/// are bound to Field values.
+///
+/// The opposite of build_labelled_hcons_constr for yuple structs
+fn build_new_labelled_tuple_struct_constr(
+    struct_name: &Ident,
+    bindnames: &Vec<Ident>,
+) -> Box<dyn ToTokens> {
+    let cloned_bind = bindnames.clone();
+    Box::new(quote! { #struct_name ( #(#cloned_bind.value),* ) })
 }

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -51,11 +51,11 @@ pub fn impl_labelled_generic(input: TokenStream) -> impl ToTokens {
     let hcons_pat = build_hcons_constr(&fnames);
     let (constructor, deconstructor) = match struct_type {
         Tuple => (
-            build_new_labelled_tuple_struct_constr(name, &fnames),
+            Box::new(build_new_labelled_tuple_struct_constr(name, &fnames)) as Box<dyn ToTokens>,
             quote! { #name ( #(#fnames, )* ) },
         ),
         Named => (
-            build_new_labelled_struct_constr(name, &fnames),
+            Box::new(build_new_labelled_struct_constr(name, &fnames)) as Box<dyn ToTokens>,
             quote! { #name { #(#fnames, )* } },
         ),
     };
@@ -216,13 +216,10 @@ fn build_field_constr_for(field: &Field) -> impl ToTokens {
 /// are bound to Field values.
 ///
 /// The opposite of build_labelled_hcons_constr for named structs
-fn build_new_labelled_struct_constr(
-    struct_name: &Ident,
-    bindnames: &Vec<Ident>,
-) -> Box<dyn ToTokens> {
+fn build_new_labelled_struct_constr(struct_name: &Ident, bindnames: &Vec<Ident>) -> impl ToTokens {
     let cloned_bind1 = bindnames.clone();
     let cloned_bind2 = bindnames.clone();
-    Box::new(quote! { #struct_name { #(#cloned_bind1: #cloned_bind2.value),* } })
+    quote! { #struct_name { #(#cloned_bind1: #cloned_bind2.value),* } }
 }
 
 /// Given a tuple struct name, and a number of Idents that act as accessors
@@ -235,7 +232,7 @@ fn build_new_labelled_struct_constr(
 fn build_new_labelled_tuple_struct_constr(
     struct_name: &Ident,
     bindnames: &Vec<Ident>,
-) -> Box<dyn ToTokens> {
+) -> impl ToTokens {
     let cloned_bind = bindnames.clone();
-    Box::new(quote! { #struct_name ( #(#cloned_bind.value),* ) })
+    quote! { #struct_name ( #(#cloned_bind.value),* ) }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -140,3 +140,15 @@ pub struct ExternalUser<'a> {
     pub address: ExternalAddress<'a>,
     pub name: &'a str,
 }
+
+#[derive(LabelledGeneric, PartialEq, Debug)]
+pub struct TypeWrapper(pub String);
+
+#[derive(LabelledGeneric, PartialEq, Debug)]
+pub struct TypeWrapper2(pub String);
+
+#[derive(LabelledGeneric, PartialEq, Debug)]
+pub struct Vec4f(pub f32, pub f32, pub f32, pub f32);
+
+#[derive(LabelledGeneric, PartialEq, Debug)]
+pub struct Vec3f(pub f32, pub f32, pub f32);

--- a/tests/labelled_tests.rs
+++ b/tests/labelled_tests.rs
@@ -170,3 +170,18 @@ fn test_generalised_auditing() {
     assert!(n_u_audited.created_at.tm_nsec >= now);
     assert!(j_u_audited.created_at.tm_nsec >= now);
 }
+
+#[test]
+fn test_conversion_between_newtypes() {
+    let s = "Foo".to_string();
+    let nt = TypeWrapper(s.clone());
+    let nt2: TypeWrapper2 = nt.transmogrify();
+    assert_eq!(nt2.0, s);
+}
+
+#[test]
+fn test_transmogrify_tuples() {
+    let vec4 = Vec4f(1.0, 2.0, 0.0, 3.0);
+    let vec3 = vec4.transmogrify();
+    assert_eq!(Vec3f(1.0, 2.0, 0.0), vec3);
+}


### PR DESCRIPTION
This is a little unusual, since it basically undoes the good that `LabelledGeneric`s by allowing someone to transmute in a way that switches the meaning of two members of the tuple but:

1. This allows mixing tuple structs (especially "new-type" structs) into `LabelledGenerics` and still transmogrify freely.
2. Tuple structs are "named" by their indexes, there's no better naming (unlike named structs where the field labels are meaningful)
3. `LabelledGeneric` is opt-in so if there's a struct that's too primitive for transmogrifying to make sense (e..g `Pair<T>(T, T)`) then don't opt-in.