### PR TITLE
#[no_std] support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,34 @@ cache: cargo
 
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
+  - rustup target add thumbv6m-none-eabi
 
 script:
   - |
-    travis-cargo build &&
-    travis-cargo build -- --example generic &&
-    travis-cargo build -- --example labelled &&
-    travis-cargo test -- --all --no-fail-fast &&
-    travis-cargo doc
+    if [[ $USE_STD == y ]]; then
+      travis-cargo build &&
+      travis-cargo build -- --example generic &&
+      travis-cargo build -- --example labelled &&
+      travis-cargo test -- --all --no-fail-fast &&
+      travis-cargo doc
+    else
+      # Can't use --all and --no-default-features together because it
+      # won't disable the default features of frunk_core.
+      travis-cargo build -- --target thumbv6m-none-eabi --no-default-features
+    fi
+
 
 after_success:
-  - travis-cargo doc-upload
+  - |
+    if [[ $USE_STD == y ]]; then
+      travis-cargo doc-upload
+    fi
   - ./travis-after-success
 
 env:
+  matrix:
+    - USE_STD=y
+    - USE_STD=n
   global:
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
     - secure: L1W/nnfhPWLFyxaHo96xewQLSFLBHUhGqlEZOwHo4L95dY48u4BgmlFjOLigO00i2yhS620e7QljI/x6zE4H0AN60vKjjX5cRSn9ksu/ZbfwhCGqZBDCoSvZkM9qS86fYPFJUpNKfA/3l0AFF+dafZd988gUhZz/3fXQNKeoiZ5kcDppWgS+2WExxsCQIUwSzu6teNd6HqCfPWdutr3CtwBn9kMkYJxyhCZEuRNePdhysEzlMVnkMywMlvcMRfc5cLRqcBwvbl7Mm5m0KdOt00vdzKwjbalE5M9Zr2Wr4trNOKY6zq5U8d5QATbySOqdI9QOHt3aT0VgHako9fXAWCyTMsMU8HDa+YahDxs2gyGrLjeKt6smbItY4OzRT9w8nhMevJDCf20IAc3h6JPQuHLKhR1ov38PAu2hS+nmqutI90HOcFyMttuyRwwjdYjsBAOX5hCUhpTTXyf8LWI3X1KUczZN6TKK1TCvUin3H/P2rp7TjPzEYyHnnsiVTiQUFX2+QPrVpWJCea+0u+FK1Bjb0AU/wycXb0ug2uX3F7gGWL8FNpKJY92eETRffh27rHp7qPCDLCe4YV8NM3Pcguk/1nbegKlgyAFAsSnQzoIiR2Va9E1S7eG9aZETckZnc+p/ZvVay87y53sb3wU14B/Ogfanv2xuq4aeQ3D7wQQ=

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ version = "0.2.4"
 [dependencies.frunk_proc_macros]
 path = "proc-macros"
 default-features = false
+optional = true
 version = "0.0.2"
 
 [dependencies.frunk_derives]
@@ -39,8 +40,9 @@ version = "0.2.4"
 serde = { version = "^1.0", optional = true, features = [ "derive" ] }
 
 [features]
-default = ["validated"]
+default = ["validated", "proc-macros"]
 validated = ["std"]
+proc-macros = ["frunk_proc_macros"]
 std = ["frunk_core/std"]
 
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ serde = { version = "^1.0", optional = true, features = [ "derive" ] }
 [features]
 default = ["validated"]
 validated = ["std"]
-std = []
+std = ["frunk_core/std"]
 
 [profile.bench]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,8 @@ serde = { version = "^1.0", optional = true, features = [ "derive" ] }
 
 [features]
 default = ["validated"]
-validated = []
+validated = ["std"]
+std = []
 
 [profile.bench]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ version = "0.2.4"
 [dependencies]
 serde = { version = "^1.0", optional = true, features = [ "derive" ] }
 
+[features]
+default = ["validated"]
+validated = []
+
 [profile.bench]
 opt-level = 3
 debug = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,22 @@ time = "0.1.36"
 
 [dependencies.frunk_core]
 path = "core"
+default-features = false
 version = "0.2.4"
 
 [dependencies.frunk_proc_macros]
 path = "proc-macros"
+default-features = false
 version = "0.0.2"
 
 [dependencies.frunk_derives]
 path = "derives"
+default-features = false
 version = "0.2.4"
 
 [dev-dependencies.frunk_laws]
 path = "laws"
+default-features = false
 version = "0.2.4"
 
 [dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,6 +11,10 @@ keywords = ["Frunk", "HList", "Generic", "Coproduct", "LabelledGeneric"]
 [badges]
 travis-ci = { repository = "lloydmeta/frunk" }
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 serde = { version = "^1.0", optional = true, features = [ "derive" ] }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,12 +16,15 @@ serde = { version = "^1.0", optional = true, features = [ "derive" ] }
 
 [dev-dependencies.frunk_derives]
 path = "../derives"
+default-features = false
 version = "0.2.4"
 
 [dev-dependencies.frunk]
 path = ".."
+default-features = false
 version = "0.2.4"
 
 [dev-dependencies.frunk_proc_macros]
 path = "../proc-macros"
+default-features = false
 version = "0.0.2"

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -999,6 +999,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_coproduct_fold_consuming() {
         type I32F32StrBool = Coprod!(i32, f32, bool);
 
@@ -1043,6 +1044,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_coproduct_fold_non_consuming() {
         type I32F32Bool = Coprod!(i32, f32, bool);
 

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -1203,6 +1203,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<H, Tail> Into<Vec<H>> for HCons<H, Tail>
 where
     Tail: Into<Vec<H>> + HList,
@@ -1218,6 +1219,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> Into<Vec<T>> for HNil {
     fn into(self) -> Vec<T> {
         Vec::with_capacity(0)

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -1408,12 +1408,12 @@ mod tests {
         let hlist_pat!(one2,) = hlist!["one"];
         assert_eq!(one2, "one");
 
-        let h = hlist![5, 3.2f32, true, "blue".to_owned()];
+        let h = hlist![5, 3.2f32, true, "blue"];
         let hlist_pat!(five, float, right, s) = h;
         assert_eq!(five, 5);
         assert_eq!(float, 3.2f32);
         assert_eq!(right, true);
-        assert_eq!(s, "blue".to_owned());
+        assert_eq!(s, "blue");
 
         let h2 = hlist![13.5f32, "hello", Some(41)];
         let hlist_pat![a, b, c,] = h2;
@@ -1523,13 +1523,13 @@ mod tests {
             }
         }
         impl Func<f32> for P {
-            type Output = String;
-            fn call(args: f32) -> Self::Output {
-                format!("{}", args)
+            type Output = &'static str;
+            fn call(_: f32) -> Self::Output {
+                "dummy"
             }
         }
         struct P;
-        assert_eq!(h.map(Poly(P)), hlist![true, 3, "41".to_string(), 6, false]);
+        assert_eq!(h.map(Poly(P)), hlist![true, 3, "dummy", 6, false]);
     }
 
     #[test]
@@ -1548,15 +1548,15 @@ mod tests {
             }
         }
         impl<'a> Func<&'a f32> for P {
-            type Output = String;
-            fn call(args: &'a f32) -> Self::Output {
-                format!("{}", args)
+            type Output = &'static str;
+            fn call(_: &'a f32) -> Self::Output {
+                "dummy"
             }
         }
         struct P;
         assert_eq!(
             h.to_ref().map(Poly(P)),
-            hlist![true, 3, "41".to_string(), 6, false]
+            hlist![true, 3, "dummy", 6, false]
         );
     }
 
@@ -1595,6 +1595,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_single_func_foldl_consuming() {
         use std::collections::HashMap;
         let h = hlist![
@@ -1611,19 +1612,14 @@ mod tests {
             },
             HashMap::with_capacity(5),
         );
-        let expected = {
-            let mut m = HashMap::with_capacity(5);
-            let vec = vec![
+        let expected: HashMap<_, _> = {
+            vec![
                 ("one", 1),
                 ("two", 2),
                 ("three", 3),
                 ("four", 4),
                 ("five", 5),
-            ];
-            for (k, v) in vec {
-                m.insert(k, v);
-            }
-            m
+            ].into_iter().collect()
         };
         assert_eq!(r, expected);
     }
@@ -1636,6 +1632,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_into_vec() {
         let h = hlist![1, 2, 3, 4, 5];
         let as_vec: Vec<_> = h.into();

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -723,6 +723,7 @@ impl<Key, SourceValue> Transmogrifier<SourceValue, IdentityTransMog> for Field<K
 
 /// Implementation of `Transmogrifier` that maps over a `Vec` in a `Field`, transmogrifying the
 /// elements on the way past.
+#[cfg(feature = "std")]
 impl<Key, Source, Target, InnerIndices>
     Transmogrifier<Vec<Target>, MappingIndicesWrapper<InnerIndices>> for Field<Key, Vec<Source>>
 where

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -416,8 +416,7 @@ where
     Type: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let v_debug = format!("{:?}", self.value);
-        write!(f, "Field{{ name: {}, value: {} }}", self.name, v_debug)
+        write!(f, "Field{{ name: {}, value: {:?} }}", self.name, self.value)
     }
 }
 
@@ -426,8 +425,7 @@ where
     Type: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let v_debug = format!("{:?}", self.value);
-        write!(f, "ValueField{{ name: {}, value: {} }}", self.name, v_debug)
+        write!(f, "ValueField{{ name: {}, value: {:?} }}", self.name, self.value)
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![doc(html_playground_url = "https://play.rust-lang.org/")]
 //! Frunk Core
 //!
@@ -56,6 +57,9 @@
 //! Links:
 //!   1. [Source on Github](https://github.com/lloydmeta/frunk)
 //!   2. [Crates.io page](https://crates.io/crates/frunk)
+
+#[cfg(not(feature = "std"))]
+extern crate core as std;
 
 #[macro_use]
 mod macros;

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -363,10 +363,10 @@ mod tests {
         let h = hlist![9000, "joe", 41f32, "schmoe", 50];
         let h2 = h.map(poly_fn!(
             |x: i32| -> bool { x > 100 },
-            |x: f32| -> String { format!("{}", x) },
+            |_x: f32| -> &'static str { "dummy" },
             ['a] |x: &'a str| -> usize { x.len() }
         ));
-        assert_eq!(h2, hlist![true, 3, "41".to_string(), 6, false]);
+        assert_eq!(h2, hlist![true, 3, "dummy", 6, false]);
     }
 
     #[test]
@@ -387,9 +387,9 @@ mod tests {
         let h = hlist![9000, "joe", 41f32, "schmoe", 50];
         let h2 = h.map(poly_fn!(
             |x: i32| -> bool { x > 100 },
-            |x: f32| -> String { format!("{}", x) },
+            |_x: f32| -> &'static str { "dummy" },
             ['a,] |x: &'a str| -> usize { x.len() },
         ));
-        assert_eq!(h2, hlist![true, 3, "41".to_string(), 6, false]);
+        assert_eq!(h2, hlist![true, 3, "dummy", 6, false]);
     }
 }

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -20,8 +20,10 @@ quote = "0.6"
 
 [dependencies.frunk_core]
 path = "../core"
+default-features = false
 version = "0.2.4"
 
 [dependencies.frunk_proc_macro_helpers]
 path = "../proc-macro-helpers"
+default-features = false
 version = "0.0.2"

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -18,11 +18,6 @@ proc-macro = true
 syn = "0.15"
 quote = "0.6"
 
-[dependencies.frunk_core]
-path = "../core"
-default-features = false
-version = "0.2.4"
-
 [dependencies.frunk_proc_macro_helpers]
 path = "../proc-macro-helpers"
 default-features = false

--- a/derives/src/lib.rs
+++ b/derives/src/lib.rs
@@ -8,7 +8,6 @@
 //!   1. [Source on Github](https://github.com/lloydmeta/frunk)
 //!   2. [Crates.io page](https://crates.io/crates/frunk)
 
-extern crate frunk_core;
 extern crate frunk_proc_macro_helpers;
 extern crate proc_macro;
 

--- a/laws/Cargo.toml
+++ b/laws/Cargo.toml
@@ -13,6 +13,7 @@ travis-ci = { repository = "lloydmeta/frunk" }
 
 [dependencies.frunk]
 path = ".."
+default-features = false
 version = "0.2.4"
 
 [dependencies]

--- a/laws/src/monoid_laws.rs
+++ b/laws/src/monoid_laws.rs
@@ -65,34 +65,40 @@ mod tests {
     use super::*;
     use frunk::semigroup::*;
     use quickcheck::quickcheck;
+    #[cfg(feature = "std")]
     use std::collections::{HashMap, HashSet};
     use wrapper::*;
 
     #[test]
+    #[cfg(feature = "std")]
     fn string_id_prop() {
         quickcheck(left_identity as fn(String) -> bool);
         quickcheck(right_identity as fn(String) -> bool);
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn option_id_prop() {
         quickcheck(left_identity as fn(Option<String>) -> bool);
         quickcheck(right_identity as fn(Option<String>) -> bool);
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn vec_id_prop() {
         quickcheck(left_identity as fn(Vec<String>) -> bool);
         quickcheck(right_identity as fn(Vec<String>) -> bool);
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn hashset_id_prop() {
         quickcheck(left_identity as fn(HashSet<i32>) -> bool);
         quickcheck(right_identity as fn(HashSet<i32>) -> bool);
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn hashmap_id_prop() {
         quickcheck(left_identity as fn(HashMap<i32, String>) -> bool);
         quickcheck(right_identity as fn(HashMap<i32, String>) -> bool);

--- a/laws/src/semigroup_laws.rs
+++ b/laws/src/semigroup_laws.rs
@@ -41,30 +41,36 @@ pub fn associativity<A: Semigroup + Eq>(a: A, b: A, c: A) -> bool {
 mod tests {
     use super::*;
     use quickcheck::quickcheck;
+    #[cfg(feature = "std")]
     use std::collections::{HashMap, HashSet};
     use wrapper::*;
 
     #[test]
+    #[cfg(feature = "std")]
     fn string_prop() {
         quickcheck(associativity as fn(String, String, String) -> bool)
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn option_prop() {
         quickcheck(associativity as fn(Option<String>, Option<String>, Option<String>) -> bool)
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn vec_prop() {
         quickcheck(associativity as fn(Vec<i8>, Vec<i8>, Vec<i8>) -> bool)
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn hashset_prop() {
         quickcheck(associativity as fn(HashSet<i8>, HashSet<i8>, HashSet<i8>) -> bool)
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn hashmap_prop() {
         quickcheck(
             associativity

--- a/proc-macro-helpers/Cargo.toml
+++ b/proc-macro-helpers/Cargo.toml
@@ -17,4 +17,5 @@ quote = "0.6"
 
 [dependencies.frunk_core]
 path = "../core"
+default-features = false
 version = "0.2.4"

--- a/proc-macros-impl/Cargo.toml
+++ b/proc-macros-impl/Cargo.toml
@@ -22,8 +22,10 @@ proc-macro = true
 
 [dependencies.frunk_core]
 path = "../core"
+default-features = false
 version = "0.2.4"
 
 [dependencies.frunk_proc_macro_helpers]
 path = "../proc-macro-helpers"
+default-features = false
 version = "0.0.2"

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -18,12 +18,15 @@ proc-macro-hack = "0.5"
 
 [dependencies.frunk_core]
 path = "../core"
+default-features = false
 version = "0.2.4"
 
 [dependencies.frunk_proc_macros_impl]
 path = "../proc-macros-impl"
+default-features = false
 version = "0.0.2"
 
 [dev-dependencies.frunk]
 path = "../."
+default-features = false
 version = "0.2.2"

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -11,10 +11,8 @@ keywords = ["Frunk", "macros"]
 [badges]
 travis-ci = { repository = "lloydmeta/frunk" }
 
-[dependencies]
-syn = "0.15"
-quote = "0.6"
-proc-macro-hack = "0.5"
+[dependencies.proc-macro-hack]
+version = "0.5"
 
 [dependencies.frunk_core]
 path = "../core"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,89 +12,90 @@
 //!   5. Semigroup
 //!   6. Monoid
 //!
-//! Here is a small taste of what Frunk has to offer:
-//!
-//! ```
-//! # #[macro_use] extern crate frunk;
-//! # #[macro_use] extern crate frunk_core;
-//! # fn main() {
-//! use frunk::prelude::*;
-//! use frunk::{self, monoid, Semigroup, Generic};
-//!
-//! // Combining Monoids
-//! let v = vec![Some(1), Some(3)];
-//! assert_eq!(monoid::combine_all(&v), Some(4));
-//!
-//! // HLists
-//! let h = hlist![1, "hi"];
-//! assert_eq!(h.len(), 2);
-//! let hlist_pat!(a, b) = h;
-//! assert_eq!(a, 1);
-//! assert_eq!(b, "hi");
-//!
-//! let h1 = hlist![Some(1), 3.3, 53i64, "hello".to_owned()];
-//! let h2 = hlist![Some(2), 1.2, 1i64, " world".to_owned()];
-//! let h3 = hlist![Some(3), 4.5, 54, "hello world".to_owned()];
-//! assert_eq!(h1.combine(&h2), h3);
-//!
-//! // Generic and LabelledGeneric-based programming
-//! // Allows Structs to play well easily with HLists
-//!
-//! #[derive(Generic, LabelledGeneric)]
-//! struct ApiUser<'a> {
-//!     FirstName: &'a str,
-//!     LastName: &'a str,
-//!     Age: usize,
-//! }
-//!
-//! #[derive(Generic, LabelledGeneric)]
-//! struct NewUser<'a> {
-//!     first_name: &'a str,
-//!     last_name: &'a str,
-//!     age: usize,
-//! }
-//!
-//! #[derive(LabelledGeneric)]
-//! struct SavedUser<'a> {
-//!     first_name: &'a str,
-//!     last_name: &'a str,
-//!     age: usize,
-//! }
-//!
-//! // Instantiate a struct from an HList. Note that you can go the other way too.
-//! let a_user: ApiUser = frunk::from_generic(hlist!["Joe", "Blow", 30]);
-//!
-//! // Convert using Generic
-//! let n_user: NewUser = Generic::convert_from(a_user); // done
-//!
-//! // Convert using LabelledGeneric
-//! //
-//! // This will fail if the fields of the types converted to and from do not
-//! // have the same names or do not line up properly :)
-//! //
-//! // Also note that we're using a helper method to avoid having to use universal
-//! // function call syntax
-//! let s_user: SavedUser = frunk::labelled_convert_from(n_user);
-//!
-//! assert_eq!(s_user.first_name, "Joe");
-//! assert_eq!(s_user.last_name, "Blow");
-//! assert_eq!(s_user.age, 30);
-//!
-//! // Uh-oh ! last_name and first_name have been flipped!
-//! #[derive(LabelledGeneric)]
-//! struct DeletedUser<'a> {
-//!     last_name: &'a str,
-//!     first_name: &'a str,
-//!     age: usize,
-//! }
-//! // let d_user = <DeletedUser as LabelledGeneric>::convert_from(s_user); <-- this would fail at compile time :)
-//!
-//! // This will, however, work, because we make use of the Sculptor type-class
-//! // to type-safely reshape the representations to align/match each other.
-//! let d_user: DeletedUser = frunk::transform_from(s_user);
-//! assert_eq!(d_user.first_name, "Joe");
-//! # }
-//! ```
+#![cfg_attr(feature = "std", doc = r#"
+Here is a small taste of what Frunk has to offer:
+
+```
+# #[macro_use] extern crate frunk;
+# #[macro_use] extern crate frunk_core;
+# fn main() {
+use frunk::prelude::*;
+use frunk::{self, monoid, Semigroup, Generic};
+
+// Combining Monoids
+let v = vec![Some(1), Some(3)];
+assert_eq!(monoid::combine_all(&v), Some(4));
+
+// HLists
+let h = hlist![1, "hi"];
+assert_eq!(h.len(), 2);
+let hlist_pat!(a, b) = h;
+assert_eq!(a, 1);
+assert_eq!(b, "hi");
+
+let h1 = hlist![Some(1), 3.3, 53i64, "hello".to_owned()];
+let h2 = hlist![Some(2), 1.2, 1i64, " world".to_owned()];
+let h3 = hlist![Some(3), 4.5, 54, "hello world".to_owned()];
+assert_eq!(h1.combine(&h2), h3);
+
+// Generic and LabelledGeneric-based programming
+// Allows Structs to play well easily with HLists
+
+#[derive(Generic, LabelledGeneric)]
+struct ApiUser<'a> {
+    FirstName: &'a str,
+    LastName: &'a str,
+    Age: usize,
+}
+
+#[derive(Generic, LabelledGeneric)]
+struct NewUser<'a> {
+    first_name: &'a str,
+    last_name: &'a str,
+    age: usize,
+}
+
+#[derive(LabelledGeneric)]
+struct SavedUser<'a> {
+    first_name: &'a str,
+    last_name: &'a str,
+    age: usize,
+}
+
+// Instantiate a struct from an HList. Note that you can go the other way too.
+let a_user: ApiUser = frunk::from_generic(hlist!["Joe", "Blow", 30]);
+
+// Convert using Generic
+let n_user: NewUser = Generic::convert_from(a_user); // done
+
+// Convert using LabelledGeneric
+//
+// This will fail if the fields of the types converted to and from do not
+// have the same names or do not line up properly :)
+//
+// Also note that we're using a helper method to avoid having to use universal
+// function call syntax
+let s_user: SavedUser = frunk::labelled_convert_from(n_user);
+
+assert_eq!(s_user.first_name, "Joe");
+assert_eq!(s_user.last_name, "Blow");
+assert_eq!(s_user.age, 30);
+
+// Uh-oh ! last_name and first_name have been flipped!
+#[derive(LabelledGeneric)]
+struct DeletedUser<'a> {
+    last_name: &'a str,
+    first_name: &'a str,
+    age: usize,
+}
+// let d_user = <DeletedUser as LabelledGeneric>::convert_from(s_user); <-- this would fail at compile time :)
+
+// This will, however, work, because we make use of the Sculptor type-class
+// to type-safely reshape the representations to align/match each other.
+let d_user: DeletedUser = frunk::transform_from(s_user);
+assert_eq!(d_user.first_name, "Joe");
+# }
+```"#)]
 //!
 //! ##### Transmogrifying
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,7 @@ extern crate frunk_derives;
 
 pub mod monoid;
 pub mod semigroup;
+#[cfg(feature = "validated")]
 pub mod validated;
 
 pub use frunk_core::*;
@@ -278,6 +279,7 @@ pub use semigroup::Semigroup;
 pub use monoid::Monoid;
 
 #[doc(no_inline)]
+#[cfg(feature = "validated")]
 pub use validated::Validated;
 
 pub mod prelude {
@@ -294,5 +296,6 @@ pub mod prelude {
     pub use hlist::LiftInto;
 
     #[doc(no_inline)]
+    #[cfg(feature = "validated")]
     pub use validated::IntoValidated;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![doc(html_playground_url = "https://play.rust-lang.org/")]
 //! Frunk: generic functional programming toolbelt for Rust
 //!
@@ -198,6 +199,9 @@
 //! Links:
 //!   1. [Source on Github](https://github.com/lloydmeta/frunk)
 //!   2. [Crates.io page](https://crates.io/crates/frunk)
+
+#[cfg(not(feature = "std"))]
+extern crate core as std;
 
 #[allow(unused_imports)]
 #[macro_use]

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -2,36 +2,37 @@
 //!
 //! A `Monoid` is a Semigroup that has a defined empty/zero value. This allows us to
 //! define a `combine_all` method to work on a list of said things:
-//!
-//! Have you ever wanted to combine 2 Hashmaps such that for a given key, if it exists in both maps,
-//! their values are summed in the new map?
-//!
-//! # Examples
-//!
-//! ```
-//! use std::collections::HashMap;
-//! use frunk::{monoid, Monoid};
-//!
-//! let vec_of_no_hashmaps: Vec<HashMap<i32, String>> = Vec::new();
-//! assert_eq!(monoid::combine_all(&vec_of_no_hashmaps),
-//!            <HashMap<i32, String> as Monoid>::empty());
-//!
-//! let mut h1: HashMap<i32, String> = HashMap::new();
-//! h1.insert(1, String::from("Hello"));  // h1 is HashMap( 1 -> "Hello")
-//! let mut h2: HashMap<i32, String> = HashMap::new();
-//! h2.insert(1, String::from(" World"));
-//! h2.insert(2, String::from("Goodbye"));  // h2 is HashMap( 1 -> " World", 2 -> "Goodbye")
-//! let mut h3: HashMap<i32, String> = HashMap::new();
-//! h3.insert(3, String::from("Cruel World")); // h3 is HashMap( 3 -> "Cruel World")
-//! let vec_of_hashes = vec![h1, h2, h3];
-//!
-//! let mut h_expected: HashMap<i32, String> = HashMap::new();
-//! h_expected.insert(1, String::from("Hello World"));
-//! h_expected.insert(2, String::from("Goodbye"));
-//! h_expected.insert(3, String::from("Cruel World"));
-//! // h_expected is HashMap ( 1 -> "Hello World", 2 -> "Goodbye", 3 -> "Cruel World")
-//! assert_eq!(monoid::combine_all(&vec_of_hashes), h_expected);
-//! ```
+#![cfg_attr(feature = "std", doc = r#"
+Have you ever wanted to combine 2 Hashmaps such that for a given key, if it exists in both maps,
+their values are summed in the new map?
+
+# Examples
+
+```
+use std::collections::HashMap;
+use frunk::{monoid, Monoid};
+
+let vec_of_no_hashmaps: Vec<HashMap<i32, String>> = Vec::new();
+assert_eq!(monoid::combine_all(&vec_of_no_hashmaps),
+           <HashMap<i32, String> as Monoid>::empty());
+
+let mut h1: HashMap<i32, String> = HashMap::new();
+h1.insert(1, String::from("Hello"));  // h1 is HashMap( 1 -> "Hello")
+let mut h2: HashMap<i32, String> = HashMap::new();
+h2.insert(1, String::from(" World"));
+h2.insert(2, String::from("Goodbye"));  // h2 is HashMap( 1 -> " World", 2 -> "Goodbye")
+let mut h3: HashMap<i32, String> = HashMap::new();
+h3.insert(3, String::from("Cruel World")); // h3 is HashMap( 3 -> "Cruel World")
+let vec_of_hashes = vec![h1, h2, h3];
+
+let mut h_expected: HashMap<i32, String> = HashMap::new();
+h_expected.insert(1, String::from("Hello World"));
+h_expected.insert(2, String::from("Goodbye"));
+h_expected.insert(3, String::from("Cruel World"));
+// h_expected is HashMap ( 1 -> "Hello World", 2 -> "Goodbye", 3 -> "Cruel World")
+assert_eq!(monoid::combine_all(&vec_of_hashes), h_expected);
+```"#)]
+
 use super::semigroup::{All, Any, Product, Semigroup};
 #[cfg(feature = "std")]
 use std::collections::*;
@@ -73,20 +74,20 @@ where
 }
 
 /// Given a sequence of `xs`, combine them and return the total
-///
-/// # Examples
-///
-/// ```
-/// use frunk::monoid::combine_all;
-///
-/// assert_eq!(combine_all(&vec![Some(1), Some(3)]), Some(4));
-///
-/// let empty_vec_opt_int:  Vec<Option<i32>> = Vec::new();
-/// assert_eq!(combine_all(&empty_vec_opt_int), None);
-///
-/// let vec_of_some_strings = vec![Some(String::from("Hello")), Some(String::from(" World"))];
-/// assert_eq!(combine_all(&vec_of_some_strings), Some(String::from("Hello World")));
-/// ```
+#[cfg_attr(feature = "std", doc = r#"
+# Examples
+
+```
+use frunk::monoid::combine_all;
+
+assert_eq!(combine_all(&vec![Some(1), Some(3)]), Some(4));
+
+let empty_vec_opt_int:  Vec<Option<i32>> = Vec::new();
+assert_eq!(combine_all(&empty_vec_opt_int), None);
+
+let some_strings = [Some(String::from("Hello")), Some(String::from(" World"))];
+assert_eq!(combine_all(&vec_of_some_strings), Some(String::from("Hello World")));
+```"#)]
 pub fn combine_all<T>(xs: &[T]) -> T
 where
     T: Monoid + Semigroup + Clone,

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -294,14 +294,11 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_combine_all_basic() {
-        assert_eq!(combine_all(&vec![1, 2, 3]), 6);
-
-        let empty_vec_int: Vec<i32> = Vec::new();
-        assert_eq!(combine_all(&empty_vec_int), 0);
-
-        let empty_vec_opt_int: Vec<Option<i32>> = Vec::new();
-        assert_eq!(combine_all(&empty_vec_opt_int), None);
+        assert_eq!(combine_all(&[1, 2, 3]), 6);
+        assert_eq!(combine_all(&[] as &[i32]), 0);
+        assert_eq!(combine_all(&[] as &[Option<i32>]), None);
 
         let vec_of_some_strings = vec![Some("Hello".to_owned()), Some(" World".to_owned())];
         assert_eq!(
@@ -311,6 +308,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_combine_all_hashset() {
         let vec_of_no_hashes: Vec<HashSet<i32>> = Vec::new();
         assert_eq!(
@@ -333,6 +331,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_combine_all_hashmap() {
         let vec_of_no_hashmaps: Vec<HashMap<i32, String>> = Vec::new();
         assert_eq!(
@@ -358,29 +357,26 @@ mod tests {
 
     #[test]
     fn test_combine_all_all() {
-        let v1: Vec<All<i32>> = Vec::new();
-        assert_eq!(combine_all(&v1), All(!0));
-        assert_eq!(combine_all(&vec![All(3), All(7)]), All(3));
+        assert_eq!(combine_all(&[] as &[All<i32>]), All(!0));
+        assert_eq!(combine_all(&[All(3), All(7)]), All(3));
 
-        let v2: Vec<All<bool>> = Vec::new();
-        assert_eq!(combine_all(&v2), All(true));
-        assert_eq!(combine_all(&vec![All(false), All(false)]), All(false));
-        assert_eq!(combine_all(&vec![All(true), All(true)]), All(true));
+        assert_eq!(combine_all(&[] as &[All<bool>]), All(true));
+        assert_eq!(combine_all(&[All(false), All(false)]), All(false));
+        assert_eq!(combine_all(&[All(true), All(true)]), All(true));
     }
 
     #[test]
     fn test_combine_all_any() {
-        let v1: Vec<Any<i32>> = Vec::new();
-        assert_eq!(combine_all(&v1), Any(0));
-        assert_eq!(combine_all(&vec![Any(3), Any(8)]), Any(11));
+        assert_eq!(combine_all(&[] as &[Any<i32>]), Any(0));
+        assert_eq!(combine_all(&[Any(3), Any(8)]), Any(11));
 
-        let v2: Vec<Any<bool>> = Vec::new();
-        assert_eq!(combine_all(&v2), Any(false));
-        assert_eq!(combine_all(&vec![Any(false), Any(false)]), Any(false));
-        assert_eq!(combine_all(&vec![Any(true), Any(false)]), Any(true));
+        assert_eq!(combine_all(&[] as &[Any<bool>]), Any(false));
+        assert_eq!(combine_all(&[Any(false), Any(false)]), Any(false));
+        assert_eq!(combine_all(&[Any(true), Any(false)]), Any(true));
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_combine_all_tuple() {
         let t1 = (1, 2.5f32, String::from("hi"), Some(3));
         let t2 = (1, 2.5f32, String::from(" world"), None);
@@ -393,7 +389,7 @@ mod tests {
 
     #[test]
     fn test_combine_all_product() {
-        let v = vec![Product(2), Product(3), Product(4)];
+        let v = [Product(2), Product(3), Product(4)];
         assert_eq!(combine_all(&v), Product(24))
     }
 

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -33,7 +33,9 @@
 //! assert_eq!(monoid::combine_all(&vec_of_hashes), h_expected);
 //! ```
 use super::semigroup::{All, Any, Product, Semigroup};
+#[cfg(feature = "std")]
 use std::collections::*;
+#[cfg(feature = "std")]
 use std::hash::Hash;
 
 /// A Monoid is a Semigroup that has an empty/ zero value
@@ -102,12 +104,14 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl Monoid for String {
     fn empty() -> Self {
         String::new()
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> Monoid for Vec<T>
 where
     T: Clone,
@@ -117,6 +121,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> Monoid for HashSet<T>
 where
     T: Hash + Eq + Clone,
@@ -126,6 +131,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<K, V> Monoid for HashMap<K, V>
 where
     K: Eq + Hash + Clone,

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -85,7 +85,7 @@ where
 /// let vec_of_some_strings = vec![Some(String::from("Hello")), Some(String::from(" World"))];
 /// assert_eq!(combine_all(&vec_of_some_strings), Some(String::from("Hello World")));
 /// ```
-pub fn combine_all<T>(xs: &Vec<T>) -> T
+pub fn combine_all<T>(xs: &[T]) -> T
 where
     T: Monoid + Semigroup + Clone,
 {

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -82,10 +82,10 @@ use frunk::monoid::combine_all;
 
 assert_eq!(combine_all(&vec![Some(1), Some(3)]), Some(4));
 
-let empty_vec_opt_int:  Vec<Option<i32>> = Vec::new();
+let empty_vec_opt_int: Vec<Option<i32>> = Vec::new();
 assert_eq!(combine_all(&empty_vec_opt_int), None);
 
-let some_strings = [Some(String::from("Hello")), Some(String::from(" World"))];
+let vec_of_some_strings = vec![Some(String::from("Hello")), Some(String::from(" World"))];
 assert_eq!(combine_all(&vec_of_some_strings), Some(String::from("Hello World")));
 ```"#)]
 pub fn combine_all<T>(xs: &[T]) -> T

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -31,8 +31,11 @@
 use frunk_core::hlist::*;
 use std::cell::*;
 use std::cmp::Ordering;
+#[cfg(feature = "std")]
 use std::collections::hash_map::Entry;
+#[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
+#[cfg(feature = "std")]
 use std::hash::Hash;
 use std::ops::{BitAnd, BitOr, Deref};
 
@@ -168,12 +171,14 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Semigroup> Semigroup for Box<T> {
     fn combine(&self, other: &Self) -> Self {
         Box::new(self.deref().combine(other.deref()))
     }
 }
 
+#[cfg(feature = "std")]
 impl Semigroup for String {
     fn combine(&self, other: &Self) -> Self {
         let mut cloned = self.clone();
@@ -182,6 +187,7 @@ impl Semigroup for String {
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Clone> Semigroup for Vec<T> {
     fn combine(&self, other: &Self) -> Self {
         let mut v = self.clone();
@@ -207,6 +213,7 @@ impl<T: Semigroup> Semigroup for RefCell<T> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> Semigroup for HashSet<T>
 where
     T: Eq + Hash + Clone,
@@ -223,6 +230,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<K, V> Semigroup for HashMap<K, V>
 where
     K: Eq + Hash + Clone,

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -405,6 +405,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_string() {
         let v1 = String::from("Hello");
         let v2 = String::from(" world");
@@ -412,6 +413,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_vec_i32() {
         let v1 = vec![1, 2, 3];
         let v2 = vec![4, 5, 6];
@@ -426,6 +428,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_hashset() {
         let mut v1 = HashSet::new();
         v1.insert(1);
@@ -444,6 +447,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_tuple() {
         let t1 = (1, 2.5f32, String::from("hi"), Some(3));
         let t2 = (1, 2.5f32, String::from(" world"), None);
@@ -457,7 +461,7 @@ mod tests {
     fn test_max() {
         assert_eq!(Max(1).combine(&Max(2)), Max(2));
 
-        let v = vec![Max(1), Max(2), Max(3)];
+        let v = [Max(1), Max(2), Max(3)];
         assert_eq!(combine_all_option(&v), Some(Max(3)));
     }
 
@@ -465,7 +469,7 @@ mod tests {
     fn test_min() {
         assert_eq!(Min(1).combine(&Min(2)), Min(1));
 
-        let v = vec![Min(1), Min(2), Min(3)];
+        let v = [Min(1), Min(2), Min(3)];
         assert_eq!(combine_all_option(&v), Some(Min(1)));
     }
 
@@ -482,6 +486,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_hashmap() {
         let mut v1: HashMap<i32, Option<String>> = HashMap::new();
         v1.insert(1, Some("Hello".to_owned()));
@@ -499,10 +504,10 @@ mod tests {
 
     #[test]
     fn test_combine_all_option() {
-        let v1 = &vec![1, 2, 3];
-        assert_eq!(combine_all_option(v1), Some(6));
-        let v2 = &vec![Some(1), Some(2), Some(3)];
-        assert_eq!(combine_all_option(v2), Some(Some(6)));
+        let v1 = [1, 2, 3];
+        assert_eq!(combine_all_option(&v1), Some(6));
+        let v2 = [Some(1), Some(2), Some(3)];
+        assert_eq!(combine_all_option(&v2), Some(Some(6)));
     }
 
     #[test]
@@ -513,6 +518,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_combine_hlist() {
         let h1 = hlist![Some(1), 3.3, 53i64, "hello".to_owned()];
         let h2 = hlist![Some(2), 1.2, 1i64, " world".to_owned()];

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -1,32 +1,32 @@
 //! Module for holding the Semigroup typeclass definition and typeclass instances
 //!
 //! You can, for example, combine tuples.
-//!
-//! # Examples
-//!
-//! ```
-//! #[macro_use]
-//! extern crate frunk;
-//!
-//! # fn main() {
-//! use frunk::Semigroup;
-//!
-//! let t1 = (1, 2.5f32, String::from("hi"), Some(3));
-//! let t2 = (1, 2.5f32, String::from(" world"), None);
-//!
-//! let expected = (2, 5.0f32, String::from("hi world"), Some(3));
-//!
-//! assert_eq!(t1.combine(&t2), expected);
-//!
-//! // ultimately, the Tuple-based Semigroup implementations are only available for a maximum of
-//! // 26 elements. If you need more, use HList, which is has no such limit.
-//!
-//! let h1 = hlist![1, 3.3, 53i64];
-//! let h2 = hlist![2, 1.2, 1i64];
-//! let h3 = hlist![3, 4.5, 54];
-//! assert_eq!(h1.combine(&h2), h3)
-//! # }
-//! ```
+#![cfg_attr(feature = "std", doc = r#"
+# Examples
+
+```
+#[macro_use]
+extern crate frunk;
+
+# fn main() {
+use frunk::Semigroup;
+
+let t1 = (1, 2.5f32, String::from("hi"), Some(3));
+let t2 = (1, 2.5f32, String::from(" world"), None);
+
+let expected = (2, 5.0f32, String::from("hi world"), Some(3));
+
+assert_eq!(t1.combine(&t2), expected);
+
+// ultimately, the Tuple-based Semigroup implementations are only available for a maximum of
+// 26 elements. If you need more, use HList, which is has no such limit.
+
+let h1 = hlist![1, 3.3, 53i64];
+let h2 = hlist![2, 1.2, 1i64];
+let h3 = hlist![3, 4.5, 54];
+assert_eq!(h1.combine(&h2), h3)
+# }
+```"#)]
 
 use frunk_core::hlist::*;
 use std::cell::*;

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -115,20 +115,12 @@ where
 /// let v2: Vec<i16> = Vec::new(); // empty!
 /// assert_eq!(combine_all_option(&v2), None);
 /// ```
-pub fn combine_all_option<T>(xs: &Vec<T>) -> Option<T>
+pub fn combine_all_option<T>(xs: &[T]) -> Option<T>
 where
     T: Semigroup + Clone,
 {
     match xs.first() {
-        Some(ref head) => {
-            let tail = xs[1..].to_vec();
-            // TODO figure out how to write this as a fold
-            let mut x = (*head).clone();
-            for i in tail {
-                x = x.combine(&i)
-            }
-            Some(x)
-        }
+        Some(head) => Some(xs[1..].iter().fold(head.clone(), |a, b| a.combine(b))),
         _ => None,
     }
 }

--- a/tests/validated_tests.rs
+++ b/tests/validated_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "validated")]
+
 extern crate frunk;
 extern crate frunk_core;
 


### PR DESCRIPTION
Closes #147

The breaking changes are:

* A change in the signature of two functions (`monoid::combine_all`, `semigroup::combine_all_option`) may break type inference
* Adding default-enabled features `std` and `validated` may break client crates using `default-features = false`.

---

The toughest part is the tests.  Several doctests were cfged out using the fact that doc comments are actually attributes.

It is crucial that `frunk_derive` does not depend on the `std` feature of `frunk_core`, or else we'd have to remove all usage of `#[derive]` from the doc tests in `frunk_core`.  This is because it is impossible to disable features of `frunk_core` enabled by `frunk_derive` due to the circular `dev-dependency`.  (features enabled by `dev-dependencies` are enabled in all builds, not just tests)

Thankfully, `frunk_derive` currently does not actually need to depend on `frunk_core` at all, so I removed the dependency.