### PR TITLE
0.2.4 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk"
-version = "0.2.2"
+version = "0.2.4"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk provides developers with a number of functional programming tools like HList, Coproduct, Generic, LabelledGeneric, Validated, Monoid, Semigroup and friends."
 license = "MIT"
@@ -17,19 +17,19 @@ time = "0.1.36"
 
 [dependencies.frunk_core]
 path = "core"
-version = "0.2.2"
+version = "0.2.4"
 
 [dependencies.frunk_proc_macros]
 path = "proc-macros"
-version = "0.0.1"
+version = "0.0.2"
 
 [dependencies.frunk_derives]
 path = "derives"
-version = "0.2.2"
+version = "0.2.4"
 
 [dev-dependencies.frunk_laws]
 path = "laws"
-version = "0.2.2"
+version = "0.2.4"
 
 [dependencies]
 serde = { version = "^1.0", optional = true, features = [ "derive" ] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_core"
-version = "0.2.2"
+version = "0.2.4"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk core provides developers with HList, Coproduct, LabelledGeneric and Generic"
 license = "MIT"
@@ -16,12 +16,12 @@ serde = { version = "^1.0", optional = true, features = [ "derive" ] }
 
 [dev-dependencies.frunk_derives]
 path = "../derives"
-version = "0.2.2"
+version = "0.2.4"
 
 [dev-dependencies.frunk]
 path = ".."
-version = "0.2.2"
+version = "0.2.4"
 
 [dev-dependencies.frunk_proc_macros]
 path = "../proc-macros"
-version = "0.0.1"
+version = "0.0.2"

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_derives"
-version = "0.2.2"
+version = "0.2.4"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "frunk_derives contains the custom derivations for certain traits in Frunk."
 license = "MIT"
@@ -20,8 +20,8 @@ quote = "0.6"
 
 [dependencies.frunk_core]
 path = "../core"
-version = "0.2.2"
+version = "0.2.4"
 
 [dependencies.frunk_proc_macro_helpers]
 path = "../proc-macro-helpers"
-version = "0.0.1"
+version = "0.0.2"

--- a/laws/Cargo.toml
+++ b/laws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_laws"
-version = "0.2.2"
+version = "0.2.4"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "frunk_laws contains laws for algebras declared in Frunk."
 license = "MIT"
@@ -13,7 +13,7 @@ travis-ci = { repository = "lloydmeta/frunk" }
 
 [dependencies.frunk]
 path = ".."
-version = "0.2.2"
+version = "0.2.4"
 
 [dependencies]
 quickcheck = "0.6.1"

--- a/proc-macro-helpers/Cargo.toml
+++ b/proc-macro-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_proc_macro_helpers"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Common internal functions for frunk's proc macros"
 license = "MIT"
@@ -17,4 +17,4 @@ quote = "0.6"
 
 [dependencies.frunk_core]
 path = "../core"
-version = "0.2.2"
+version = "0.2.4"

--- a/proc-macros-impl/Cargo.toml
+++ b/proc-macros-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_proc_macros_impl"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Proc macros inernal implementations for Frunk"
 license = "MIT"
@@ -22,8 +22,8 @@ proc-macro = true
 
 [dependencies.frunk_core]
 path = "../core"
-version = "0.2.2"
+version = "0.2.4"
 
 [dependencies.frunk_proc_macro_helpers]
 path = "../proc-macro-helpers"
-version = "0.0.1"
+version = "0.0.2"

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_proc_macros"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Proc macros for Frunk"
 license = "MIT"
@@ -18,11 +18,11 @@ proc-macro-hack = "0.5"
 
 [dependencies.frunk_core]
 path = "../core"
-version = "0.2.2"
+version = "0.2.4"
 
 [dependencies.frunk_proc_macros_impl]
 path = "../proc-macros-impl"
-version = "0.0.1"
+version = "0.0.2"
 
 [dev-dependencies.frunk]
 path = "../."


### PR DESCRIPTION
0.2.3 got skipped along with a bunch of other things due to failure to
properly bootstrap my way around dev-circular dependencies due to
not realising that [Cargo doesn't understand pre-release versions](https://github.com/rust-lang/cargo/issues/2222).