### PR TITLE
Refactor derives

### DIFF
--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -1554,10 +1554,7 @@ mod tests {
             }
         }
         struct P;
-        assert_eq!(
-            h.to_ref().map(Poly(P)),
-            hlist![true, 3, "dummy", 6, false]
-        );
+        assert_eq!(h.to_ref().map(Poly(P)), hlist![true, 3, "dummy", 6, false]);
     }
 
     #[test]
@@ -1619,7 +1616,9 @@ mod tests {
                 ("three", 3),
                 ("four", 4),
                 ("five", 5),
-            ].into_iter().collect()
+            ]
+            .into_iter()
+            .collect()
         };
         assert_eq!(r, expected);
     }

--- a/derives/src/derive_generic.rs
+++ b/derives/src/derive_generic.rs
@@ -37,10 +37,8 @@ pub fn impl_generic(input: TokenStream) -> impl ToTokens {
                     }
                 }
             }
-        },
-        _ => panic!(
-            "Only Structs are supported. Enums/Unions cannot be turned into Generics."
-        ),
+        }
+        _ => panic!("Only Structs are supported. Enums/Unions cannot be turned into Generics."),
     };
 
     //     print!("{}", tree);

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -73,7 +73,7 @@ pub fn impl_labelled_generic(input: TokenStream) -> impl ToTokens {
 
                 }
             }
-        },
+        }
         _ => panic!(
             "Only Structs are supported. Enums/Unions cannot be turned into Labelled Generics."
         ),

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -1,17 +1,7 @@
 use frunk_proc_macro_helpers::*;
 use proc_macro::TokenStream;
 use quote::ToTokens;
-use quote::__rt::Span;
-use syn::spanned::Spanned;
-use syn::{
-    Data, Field, Fields, FieldsUnnamed, GenericParam, Generics, Ident, Lifetime, LifetimeDef,
-};
-
-enum StructType {
-    Named,
-    Tuple,
-}
-use self::StructType::*;
+use syn::Data;
 
 /// Given an AST, returns an implementation of Generic using HList with
 /// Field (see frunk_core::labelled) elements
@@ -20,262 +10,75 @@ use self::StructType::*;
 pub fn impl_labelled_generic(input: TokenStream) -> impl ToTokens {
     let ast = to_ast(input);
     let name = &ast.ident;
+
     let generics = &ast.generics;
-
-    let mut generics_ref: Generics = generics.clone();
+    let generics_ref = ref_generics(generics);
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-    // instantiate a lifetime and lifetime def to add
-    let ref_lifetime = Lifetime::new("'_frunk_labelled_generic_ref_", Span::call_site());
-    let ref_lifetime_def = LifetimeDef::new(ref_lifetime.clone());
-
-    // Constrain the generic lifetimes present in the concrete type to the reference lifetime
-    // of our implementation of LabelledGeneric for the reference case (& and &mut)
-    {
-        let generics_ref_lifetimes_mut = generics_ref.lifetimes_mut();
-        for existing_lifetime_mut in generics_ref_lifetimes_mut {
-            existing_lifetime_mut.bounds.push(ref_lifetime.clone());
-        }
-    }
-
-    // Add our current generic lifetime to the list of generics
-    let ref_lifetime_generic = GenericParam::Lifetime(ref_lifetime_def);
-    generics_ref.params.push(ref_lifetime_generic);
-
-    // Get the generics back out for our reference types
     let (impl_generics_ref, _, where_clause_ref) = generics_ref.split_for_impl();
-    let impl_generics_mut_ref = impl_generics_ref.clone();
-    let where_clause_mut_ref = where_clause_ref.clone();
 
-    let (struct_type, fields): (StructType, Vec<Field>) = match ast.data {
-        Data::Struct(ref data) => match data.fields {
-            Fields::Named(ref fields) => (Named, fields.named.iter().cloned().collect()),
-            Fields::Unnamed(ref fields) => (Tuple, create_indexed_fields(fields)),
-            Fields::Unit => panic!("Unit structs cannot be turned into Labelled Generics"),
+    let tree = match ast.data {
+        Data::Struct(ref data) => {
+            let field_bindings = FieldBindings::new(&data.fields);
+            let repr_type = field_bindings.build_hlist_type(FieldBinding::build_field_type);
+            let repr_type_ref = field_bindings.build_hlist_type(FieldBinding::build_field_type_ref);
+            let repr_type_mut = field_bindings.build_hlist_type(FieldBinding::build_field_type_mut);
+            let hcons_expr = field_bindings.build_hlist_constr(FieldBinding::build_field_expr);
+            let hcons_pat = field_bindings.build_hlist_constr(FieldBinding::build_field_pat);
+            let type_constr = field_bindings.build_type_constr(FieldBinding::build);
+            let type_pat_ref = field_bindings.build_type_constr(FieldBinding::build_pat_ref);
+            let type_pat_mut = field_bindings.build_type_constr(FieldBinding::build_pat_mut);
+
+            quote! {
+                #[allow(non_snake_case, non_camel_case_types)]
+                impl #impl_generics ::frunk_core::labelled::LabelledGeneric for #name #ty_generics #where_clause {
+
+                    type Repr = #repr_type;
+
+                    #[inline(always)]
+                    fn into(self) -> Self::Repr {
+                        let #name #type_constr = self;
+                        #hcons_expr
+                    }
+
+                    #[inline(always)]
+                    fn from(r: Self::Repr) -> Self {
+                        let #hcons_pat = r;
+                        #name #type_constr
+                    }
+                }
+
+                #[allow(non_snake_case, non_camel_case_types)]
+                impl #impl_generics_ref ::frunk_core::labelled::IntoLabelledGeneric for & '_frunk_ref_ #name #ty_generics #where_clause_ref {
+
+                    type Repr = #repr_type_ref;
+
+                    #[inline(always)]
+                    fn into(self) -> Self::Repr {
+                        let #name #type_pat_ref = *self;
+                        #hcons_expr
+                    }
+
+                }
+
+                #[allow(non_snake_case, non_camel_case_types)]
+                impl #impl_generics_ref ::frunk_core::labelled::IntoLabelledGeneric for & '_frunk_ref_ mut #name #ty_generics #where_clause_ref {
+
+                    type Repr = #repr_type_mut;
+
+                    #[inline(always)]
+                    fn into(self) -> Self::Repr {
+                        let #name #type_pat_mut = *self;
+                        #hcons_expr
+                    }
+
+                }
+            }
         },
         _ => panic!(
             "Only Structs are supported. Enums/Unions cannot be turned into Labelled Generics."
         ),
     };
 
-    let repr_type = build_labelled_repr(&fields, SelfKind::Value);
-    let ref_repr_type = build_labelled_repr(&fields, SelfKind::Ref);
-    let mut_ref_repr_type = build_labelled_repr(&fields, SelfKind::MutRef);
-    let fnames: Vec<Ident> = fields
-        .iter()
-        // it's impossible to not have idents because we create synthetic names for tuple structs
-        .map(|f| f.ident.clone().unwrap())
-        .collect();
-    let fnames_ref = fnames.clone();
-    let fnames_mut_ref = fnames.clone();
-
-    let hcons_constr = build_labelled_hcons_constr(&fields, SelfKind::Value);
-    let hcons_constr_ref = build_labelled_hcons_constr(&fields, SelfKind::Ref);
-    let hcons_constr_mut_ref = build_labelled_hcons_constr(&fields, SelfKind::MutRef);
-
-    let hcons_pat = build_hcons_constr(&fnames);
-    let (constructor, deconstructor) = match struct_type {
-        Tuple => (
-            Box::new(build_new_labelled_tuple_struct_constr(name, &fnames)) as Box<dyn ToTokens>,
-            quote! { #name ( #(#fnames, )* ) },
-        ),
-        Named => (
-            Box::new(build_new_labelled_struct_constr(name, &fnames)) as Box<dyn ToTokens>,
-            quote! { #name { #(#fnames, )* } },
-        ),
-    };
-    let struct_ref_deconstr = match struct_type {
-        Tuple => quote! { #name ( #(ref #fnames_ref, )* ) },
-        Named => quote! { #name { #(ref #fnames_ref, )* } },
-    };
-    let struct_mut_ref_deconstr = match struct_type {
-        Tuple => quote! { #name ( #(ref mut #fnames_mut_ref, )* ) },
-        Named => quote! { #name { #(ref mut #fnames_mut_ref, )* } },
-    };
-    let tree = quote! {
-        #[allow(non_snake_case, non_camel_case_types)]
-        impl #impl_generics ::frunk_core::labelled::LabelledGeneric for #name #ty_generics #where_clause {
-
-            type Repr = #repr_type;
-
-            #[inline(always)]
-            fn into(self) -> Self::Repr {
-                let #deconstructor = self;
-                #hcons_constr
-            }
-
-            #[inline(always)]
-            fn from(r: Self::Repr) -> Self {
-                let #hcons_pat = r;
-                #constructor
-            }
-        }
-
-        #[allow(non_snake_case, non_camel_case_types)]
-        impl #impl_generics_ref ::frunk_core::labelled::IntoLabelledGeneric for & '_frunk_labelled_generic_ref_ #name #ty_generics #where_clause_ref {
-
-            type Repr = #ref_repr_type;
-
-            #[inline(always)]
-            fn into(self) -> Self::Repr {
-                let #struct_ref_deconstr = *self;
-                #hcons_constr_ref
-            }
-
-        }
-
-        #[allow(non_snake_case, non_camel_case_types)]
-        impl #impl_generics_mut_ref ::frunk_core::labelled::IntoLabelledGeneric for & '_frunk_labelled_generic_ref_ mut #name #ty_generics #where_clause_mut_ref {
-
-            type Repr = #mut_ref_repr_type;
-
-            #[inline(always)]
-            fn into(self) -> Self::Repr {
-                let #struct_mut_ref_deconstr = *self;
-                #hcons_constr_mut_ref
-            }
-
-        }
-    };
     //     print!("{}", tree);
     tree
-}
-
-/// Create synthetic names for tuple struct members
-fn create_indexed_fields(fields: &FieldsUnnamed) -> Vec<Field> {
-    fields
-        .unnamed
-        .iter()
-        .enumerate()
-        .map(|(i, f)| {
-            let mut f = f.clone();
-            f.ident = Some(Ident::new(&format!("_{}", i), f.span()));
-            f
-        })
-        .collect()
-}
-
-/// Builds the labelled HList representation for a vector of fields
-fn build_labelled_repr(fields: &Vec<Field>, self_kind: SelfKind) -> impl ToTokens {
-    match fields.len() {
-        0 => quote! { ::frunk_core::hlist::HNil },
-        1 => {
-            let field = fields[0].clone();
-            let labelled_type = build_labelled_type_for(&field, self_kind);
-            quote! { ::frunk_core::hlist::HCons<#labelled_type, ::frunk_core::hlist::HNil> }
-        }
-        _ => {
-            let field = fields[0].clone();
-            let labelled_type = build_labelled_type_for(&field, self_kind.clone());
-            let tail = fields[1..].to_vec();
-            let tail_type = build_labelled_repr(&tail, self_kind.clone());
-            quote! { ::frunk_core::hlist::HCons<#labelled_type, #tail_type> }
-        }
-    }
-}
-
-/// Given a field, returns an AST for its Field (see labelled module in core) type,
-/// which holds its name (or an approximation) and type.
-fn build_labelled_type_for(field: &Field, self_kind: SelfKind) -> impl ToTokens {
-    let ident = field.clone().ident.unwrap(); // this method is for labelled structs only
-    let name_as_type = build_type_level_name_for(&ident);
-    let ref field_type = field.ty;
-    match self_kind {
-        SelfKind::Value => quote! { ::frunk_core::labelled::Field<#name_as_type, #field_type> },
-        SelfKind::Ref => {
-            quote! { ::frunk_core::labelled::Field<#name_as_type, &'_frunk_labelled_generic_ref_ #field_type> }
-        }
-        SelfKind::MutRef => {
-            quote! { ::frunk_core::labelled::Field<#name_as_type, &'_frunk_labelled_generic_ref_ mut #field_type> }
-        }
-    }
-}
-
-/// Given a number of Idents that act as accessors and struct member
-/// names, returns an AST representing how to construct an HList containing
-/// Field values.
-///
-/// Assumes that there are bindings in the immediate environment with those names that
-/// are bound to properly-typed values.
-fn build_labelled_hcons_constr(fields: &Vec<Field>, self_kind: SelfKind) -> impl ToTokens {
-    match fields.len() {
-        0 => quote! { ::frunk_core::hlist::HNil },
-        1 => {
-            let field = fields[0].clone();
-            let labelled_constructor = build_field_constr_for(&field, self_kind);
-            quote! { ::frunk_core::hlist::HCons{ head: #labelled_constructor, tail: ::frunk_core::hlist::HNil } }
-        }
-        _ => {
-            let field = fields[0].clone();
-            let labelled_constructor = build_field_constr_for(&field, self_kind);
-            let tail = fields[1..].to_vec();
-            let hlist_tail = build_labelled_hcons_constr(&tail, self_kind);
-            quote! { ::frunk_core::hlist::HCons{ head: #labelled_constructor, tail: #hlist_tail }}
-        }
-    }
-}
-
-/// Given a field, returns an AST for calling the Field constructor that holds its
-/// value.
-///
-/// This calls a method in frunk_core::labelled called "field_with_name", filling in the value and the
-/// field name.
-///
-/// For example, given a field "age" of type i32, returns: field_with_name::<(a,g,e), i32>(age, "age")
-fn build_field_constr_for(field: &Field, self_kind: SelfKind) -> impl ToTokens {
-    let name_as_type = build_type_level_name_for(&field.clone().ident.unwrap());
-    let field_type = field.ty.clone();
-    let field_name = field.ident.clone();
-    let field_name_str = field
-        .ident
-        .clone()
-        .expect("Field name should exist!")
-        .to_string();
-
-    match self_kind {
-        SelfKind::Value => {
-            quote! { ::frunk_core::labelled::field_with_name::<#name_as_type, #field_type>(#field_name_str, #field_name) }
-        }
-        SelfKind::Ref => {
-            quote! { ::frunk_core::labelled::field_with_name::<#name_as_type, &'_frunk_labelled_generic_ref_ #field_type>(#field_name_str, #field_name) }
-        }
-        SelfKind::MutRef => {
-            quote! { ::frunk_core::labelled::field_with_name::<#name_as_type, &'_frunk_labelled_generic_ref_ mut #field_type>(#field_name_str, #field_name) }
-        }
-    }
-}
-
-/// Given a struct name, and a number of Idents that act as accessors and struct member
-/// names, returns an AST representing how to construct said struct.
-///
-/// Assumes that there are bindings in the immediate environment with those names that
-/// are bound to Field values.
-///
-/// The opposite of build_labelled_hcons_constr for named structs
-fn build_new_labelled_struct_constr(struct_name: &Ident, bindnames: &Vec<Ident>) -> impl ToTokens {
-    let cloned_bind1 = bindnames.clone();
-    let cloned_bind2 = bindnames.clone();
-    quote! { #struct_name { #(#cloned_bind1: #cloned_bind2.value),* } }
-}
-
-#[derive(Copy, Clone)]
-enum SelfKind {
-    Value,
-    Ref,
-    MutRef,
-}
-
-/// Given a tuple struct name, and a number of Idents that act as accessors
-/// names, returns an AST representing how to construct said tuple struct.
-///
-/// Assumes that there are bindings in the immediate environment with those names that
-/// are bound to Field values.
-///
-/// The opposite of build_labelled_hcons_constr for yuple structs
-fn build_new_labelled_tuple_struct_constr(
-    struct_name: &Ident,
-    bindnames: &Vec<Ident>,
-) -> impl ToTokens {
-    let cloned_bind = bindnames.clone();
-    quote! { #struct_name ( #(#cloned_bind.value),* ) }
 }

--- a/proc-macro-helpers/Cargo.toml
+++ b/proc-macro-helpers/Cargo.toml
@@ -14,6 +14,7 @@ travis-ci = { repository = "lloydmeta/frunk" }
 [dependencies]
 syn = "0.15"
 quote = "0.6"
+proc-macro2 = "0.4"
 
 [dependencies.frunk_core]
 path = "../core"

--- a/proc-macro-helpers/src/lib.rs
+++ b/proc-macro-helpers/src/lib.rs
@@ -19,8 +19,10 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::ToTokens;
 use quote::__rt::Span;
-use syn::{DeriveInput, Expr, Ident, Member, Fields, Field, Generics, GenericParam, Lifetime, LifetimeDef};
 use syn::spanned::Spanned;
+use syn::{
+    DeriveInput, Expr, Field, Fields, GenericParam, Generics, Ident, Lifetime, LifetimeDef, Member,
+};
 
 /// These are assumed to exist as enums in frunk_core::labelled
 const ALPHA_CHARS: &'static [char] = &[
@@ -50,7 +52,7 @@ pub fn call_site_ident(s: &str) -> Ident {
 pub fn build_hlist_type<L: IntoIterator>(items: L) -> TokenStream2
 where
     L::Item: ToTokens,
-    L::IntoIter: DoubleEndedIterator
+    L::IntoIter: DoubleEndedIterator,
 {
     let mut result = quote! { ::frunk_core::hlist::HNil };
     for item in items.into_iter().rev() {
@@ -64,7 +66,7 @@ where
 pub fn build_hlist_constr<L: IntoIterator>(items: L) -> TokenStream2
 where
     L::Item: ToTokens,
-    L::IntoIter: DoubleEndedIterator
+    L::IntoIter: DoubleEndedIterator,
 {
     let mut result = quote! { ::frunk_core::hlist::HNil };
     for item in items.into_iter().rev() {
@@ -120,9 +122,10 @@ fn encode_as_ident(c: &char) -> Vec<Ident> {
 
 pub fn build_path_type(path_expr: Expr) -> impl ToTokens {
     let idents = find_idents_in_expr(path_expr);
-    idents.iter().map(|i| build_label_type(i)).fold(
-        quote!(::frunk_core::hlist::HNil),
-        |acc, t| {
+    idents
+        .iter()
+        .map(|i| build_label_type(i))
+        .fold(quote!(::frunk_core::hlist::HNil), |acc, t| {
             quote! {
             ::frunk_core::path::Path<
                 ::frunk_core::hlist::HCons<
@@ -131,8 +134,7 @@ pub fn build_path_type(path_expr: Expr) -> impl ToTokens {
                 >
               >
             }
-        },
-    )
+        })
 }
 
 /// Returns the idents in a path like expression in reverse
@@ -242,12 +244,17 @@ impl FieldBindings {
                 Fields::Unnamed(_) => StructType::Tuple,
                 Fields::Unit => StructType::Unit,
             },
-            fields: fields.iter().enumerate().map(|(index, field)| FieldBinding {
-                field: field.clone(),
-                binding: field.ident.clone().unwrap_or_else(
-                    || Ident::new(&format!("_{}", index), field.span())
-                ),
-            }).collect()
+            fields: fields
+                .iter()
+                .enumerate()
+                .map(|(index, field)| FieldBinding {
+                    field: field.clone(),
+                    binding: field
+                        .ident
+                        .clone()
+                        .unwrap_or_else(|| Ident::new(&format!("_{}", index), field.span())),
+                })
+                .collect(),
         }
     }
 
@@ -272,7 +279,6 @@ impl FieldBindings {
 }
 
 pub fn ref_generics(generics: &Generics) -> Generics {
-    
     let mut generics_ref = generics.clone();
 
     // instantiate a lifetime and lifetime def to add

--- a/proc-macro-helpers/src/lib.rs
+++ b/proc-macro-helpers/src/lib.rs
@@ -9,15 +9,18 @@
 
 extern crate frunk_core;
 extern crate proc_macro;
+extern crate proc_macro2;
 
 #[macro_use]
 extern crate quote;
 extern crate syn;
 
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
 use quote::ToTokens;
 use quote::__rt::Span;
-use syn::{DeriveInput, Expr, Ident, Member};
+use syn::{DeriveInput, Expr, Ident, Member, Fields, Field, Generics, GenericParam, Lifetime, LifetimeDef};
+use syn::spanned::Spanned;
 
 /// These are assumed to exist as enums in frunk_core::labelled
 const ALPHA_CHARS: &'static [char] = &[
@@ -42,31 +45,39 @@ pub fn call_site_ident(s: &str) -> Ident {
     Ident::new(s, Span::call_site())
 }
 
-/// Given a identifiers, creates an AST for building an HList (HCons)
-/// using those identifiers as accessors.
-///
-/// Subsequently, this same function can be used for pattern matching too!
-pub fn build_hcons_constr(accessors: &Vec<Ident>) -> impl ToTokens {
-    match accessors.len() {
-        0 => quote! { ::frunk_core::hlist::HNil },
-        1 => {
-            let h = accessors[0].clone();
-            quote! { ::frunk_core::hlist::HCons{ head: #h, tail: ::frunk_core::hlist::HNil } }
-        }
-        _ => {
-            let h = accessors[0].clone();
-            let tail = accessors[1..].to_vec();
-            let hlist_tail = build_hcons_constr(&tail);
-            quote! { ::frunk_core::hlist::HCons{ head: #h, tail: #hlist_tail }}
-        }
+/// Given a list of types, creates an AST for the corresponding HList
+/// type.
+pub fn build_hlist_type<L: IntoIterator>(items: L) -> TokenStream2
+where
+    L::Item: ToTokens,
+    L::IntoIter: DoubleEndedIterator
+{
+    let mut result = quote! { ::frunk_core::hlist::HNil };
+    for item in items.into_iter().rev() {
+        result = quote! { ::frunk_core::hlist::HCons<#item, #result> }
     }
+    result
+}
+
+/// Given a list of expressions or patterns, creates an AST for the corresponding HList
+/// constructor, which may itself be used as an expression or a pattern.
+pub fn build_hlist_constr<L: IntoIterator>(items: L) -> TokenStream2
+where
+    L::Item: ToTokens,
+    L::IntoIter: DoubleEndedIterator
+{
+    let mut result = quote! { ::frunk_core::hlist::HNil };
+    for item in items.into_iter().rev() {
+        result = quote! { ::frunk_core::hlist::HCons { head: #item, tail: #result }}
+    }
+    result
 }
 
 /// Given an Ident returns an AST for its type level representation based on the
 /// enums generated in frunk_core::labelled.
 ///
-/// For example, given first_name, returns an AST for Hlist!(f,i,r,s,t,__,n,a,m,e)
-pub fn build_type_level_name_for(ident: &Ident) -> impl ToTokens {
+/// For example, given first_name, returns an AST for (f,i,r,s,t,__,n,a,m,e)
+pub fn build_label_type(ident: &Ident) -> impl ToTokens {
     let as_string = ident.to_string();
     let name = as_string.as_str();
     let name_as_idents: Vec<Ident> = name.chars().flat_map(|c| encode_as_ident(&c)).collect();
@@ -109,7 +120,7 @@ fn encode_as_ident(c: &char) -> Vec<Ident> {
 
 pub fn build_path_type(path_expr: Expr) -> impl ToTokens {
     let idents = find_idents_in_expr(path_expr);
-    idents.iter().map(|i| build_type_level_name_for(i)).fold(
+    idents.iter().map(|i| build_label_type(i)).fold(
         quote!(::frunk_core::hlist::HNil),
         |acc, t| {
             quote! {
@@ -151,4 +162,135 @@ pub fn find_idents_in_expr(path_expr: Expr) -> Vec<Ident> {
         }
     }
     go(path_expr, Vec::new())
+}
+
+pub enum StructType {
+    Named,
+    Tuple,
+    Unit,
+}
+
+pub struct FieldBinding {
+    pub field: Field,
+    pub binding: Ident,
+}
+
+impl FieldBinding {
+    pub fn build_type(&self) -> TokenStream2 {
+        let ty = &self.field.ty;
+        quote! { #ty }
+    }
+    pub fn build_type_ref(&self) -> TokenStream2 {
+        let ty = &self.field.ty;
+        quote! { &'_frunk_ref_ #ty }
+    }
+    pub fn build_type_mut(&self) -> TokenStream2 {
+        let ty = &self.field.ty;
+        quote! { &'_frunk_ref_ mut #ty }
+    }
+    pub fn build_field_type(&self) -> TokenStream2 {
+        let label_type = build_label_type(&self.binding);
+        let ty = &self.field.ty;
+        quote! { ::frunk_core::labelled::Field<#label_type, #ty> }
+    }
+    pub fn build_field_type_ref(&self) -> TokenStream2 {
+        let label_type = build_label_type(&self.binding);
+        let ty = &self.field.ty;
+        quote! { ::frunk_core::labelled::Field<#label_type, &'_frunk_ref_ #ty> }
+    }
+    pub fn build_field_type_mut(&self) -> TokenStream2 {
+        let label_type = build_label_type(&self.binding);
+        let ty = &self.field.ty;
+        quote! { ::frunk_core::labelled::Field<#label_type, &'_frunk_ref_ mut #ty> }
+    }
+    pub fn build(&self) -> TokenStream2 {
+        let binding = &self.binding;
+        quote! { #binding }
+    }
+    pub fn build_pat_ref(&self) -> TokenStream2 {
+        let binding = &self.binding;
+        quote! { ref #binding }
+    }
+    pub fn build_pat_mut(&self) -> TokenStream2 {
+        let binding = &self.binding;
+        quote! { ref mut #binding }
+    }
+    pub fn build_field_expr(&self) -> TokenStream2 {
+        let label_type = build_label_type(&self.binding);
+        let binding = &self.binding;
+        let literal_name = self.binding.to_string();
+        quote! { ::frunk_core::labelled::field_with_name::<#label_type, _>(#literal_name, #binding) }
+    }
+    pub fn build_field_pat(&self) -> TokenStream2 {
+        let binding = &self.binding;
+        quote! { ::frunk_core::labelled::Field { value: #binding, .. } }
+    }
+}
+
+/// Represents the binding of a struct or enum variant's fields to a corresponding
+/// set of similarly named local variables.
+pub struct FieldBindings {
+    pub type_: StructType,
+    pub fields: Vec<FieldBinding>,
+}
+
+impl FieldBindings {
+    pub fn new(fields: &Fields) -> Self {
+        Self {
+            type_: match fields {
+                Fields::Named(_) => StructType::Named,
+                Fields::Unnamed(_) => StructType::Tuple,
+                Fields::Unit => StructType::Unit,
+            },
+            fields: fields.iter().enumerate().map(|(index, field)| FieldBinding {
+                field: field.clone(),
+                binding: field.ident.clone().unwrap_or_else(
+                    || Ident::new(&format!("_{}", index), field.span())
+                ),
+            }).collect()
+        }
+    }
+
+    /// Builds a type constructor for use with structs or enum variants. Does not include the name
+    /// of the type or variant.
+    pub fn build_type_constr<R: ToTokens>(&self, f: impl Fn(&FieldBinding) -> R) -> TokenStream2 {
+        let bindings: Vec<_> = self.fields.iter().map(f).collect();
+        match self.type_ {
+            StructType::Named => quote! { { #(#bindings,)* } },
+            StructType::Tuple => quote! { ( #(#bindings,)* ) },
+            StructType::Unit => TokenStream2::new(),
+        }
+    }
+
+    pub fn build_hlist_type<R: ToTokens>(&self, f: impl Fn(&FieldBinding) -> R) -> TokenStream2 {
+        build_hlist_type(self.fields.iter().map(f))
+    }
+
+    pub fn build_hlist_constr<R: ToTokens>(&self, f: impl Fn(&FieldBinding) -> R) -> TokenStream2 {
+        build_hlist_constr(self.fields.iter().map(f))
+    }
+}
+
+pub fn ref_generics(generics: &Generics) -> Generics {
+    
+    let mut generics_ref = generics.clone();
+
+    // instantiate a lifetime and lifetime def to add
+    let ref_lifetime = Lifetime::new("'_frunk_ref_", Span::call_site());
+    let ref_lifetime_def = LifetimeDef::new(ref_lifetime.clone());
+
+    // Constrain the generic lifetimes present in the concrete type to the reference lifetime
+    // of our implementation of LabelledGeneric for the reference case (& and &mut)
+    {
+        let generics_ref_lifetimes_mut = generics_ref.lifetimes_mut();
+        for existing_lifetime_mut in generics_ref_lifetimes_mut {
+            existing_lifetime_mut.bounds.push(ref_lifetime.clone());
+        }
+    }
+
+    // Add our current generic lifetime to the list of generics
+    let ref_lifetime_generic = GenericParam::Lifetime(ref_lifetime_def);
+    generics_ref.params.push(ref_lifetime_generic);
+
+    generics_ref
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,9 @@
 //!   5. Semigroup
 //!   6. Monoid
 //!
-#![cfg_attr(feature = "std", doc = r#"
+#![cfg_attr(
+    feature = "std",
+    doc = r#"
 Here is a small taste of what Frunk has to offer:
 
 ```
@@ -95,7 +97,8 @@ struct DeletedUser<'a> {
 let d_user: DeletedUser = frunk::transform_from(s_user);
 assert_eq!(d_user.first_name, "Joe");
 # }
-```"#)]
+```"#
+)]
 //!
 //! ##### Transmogrifying
 //!

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -74,7 +74,9 @@ where
 }
 
 /// Given a sequence of `xs`, combine them and return the total
-#[cfg_attr(feature = "std", doc = r#"
+#[cfg_attr(
+    feature = "std",
+    doc = r#"
 # Examples
 
 ```
@@ -87,7 +89,8 @@ assert_eq!(combine_all(&empty_vec_opt_int), None);
 
 let vec_of_some_strings = vec![Some(String::from("Hello")), Some(String::from(" World"))];
 assert_eq!(combine_all(&vec_of_some_strings), Some(String::from("Hello World")));
-```"#)]
+```"#
+)]
 pub fn combine_all<T>(xs: &[T]) -> T
 where
     T: Monoid + Semigroup + Clone,


### PR DESCRIPTION
This should make it much easier to extend these derives to support enums.

The only change to behaviour should be that `LabelledGeneric` can now be derived on unit structs.

Changes to the generated code:
- Renamed `'_frunk_labelled_generic_ref_` to `_frunk_ref_` because the new code is no longer specific to labelled generics. It would be easy to extend the "ref" implementations to support plain `Generic` if desired.

- Instead of extracting the `value` from `Field`s using property accessor syntax (`field.value`) it is destructed directly from the HList, using `Field { value: <x>, .. }`. This has the advantage of allowing the construction and destructuring of the user's type to use identical syntax.

Changes to naming conventions:
- There are three main "places" where generated code is used: types, expressions and patterns. This is complicated by the fact that much syntax is valid as both an expression and a pattern. The convention I used is for `build_xxx_constr` methods to be usable in both expression and pattern locations, whilst `build_xxx_type`, `build_xxx_expr` and `build_xxx_pat` methods are self explanatory.

- For normal/ref/mutable ref variations, always use the suffixes <none>/_ref/_mut.

There are several features that could be added as follow-ups to this PR:
- Addition of `IntoGeneric` trait and implementation of `Generic` for references to types deriving `Generic`.
- Support for deriving `Generic` and `LabelledGeneric` on enums.

Are these features you would want to add?
