### PR TITLE
Support deriving LabelledGeneric on enums

### DIFF
--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -167,7 +167,7 @@ pub fn impl_labelled_generic(input: TokenStream) -> impl ToTokens {
             quote! { #base_impl #ref_impl #mut_impl }
         }
         _ => panic!(
-            "Only Structs are supported. Enums/Unions cannot be turned into Labelled Generics."
+            "Only Structs and Enums can be turned into Labelled Generics."
         ),
     };
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -152,3 +152,17 @@ pub struct Vec4f(pub f32, pub f32, pub f32, pub f32);
 
 #[derive(LabelledGeneric, PartialEq, Debug)]
 pub struct Vec3f(pub f32, pub f32, pub f32);
+
+#[derive(LabelledGeneric, PartialEq, Debug)]
+pub enum LabelledEnum1 {
+    VariantA,
+    VariantB(i32),
+    VariantC { x: String, y: bool },
+}
+
+#[derive(LabelledGeneric, PartialEq, Debug)]
+pub enum LabelledEnum2 {
+    VariantA,
+    VariantC { x: String, y: bool },
+    VariantB(i32),
+}


### PR DESCRIPTION
(Based off #157)

I reused the `Field` type to represent named enum variants.

This is just the first step - to make enums actually useful we'll need to:
- Support "taking", etc. by field *name* only.
- Implement a general-purpose "sculpt"-like function which works on HLists/Coproducts of Fields, and only uses the field's *name* to determine the sculpting to perform.
- Make this work recursively, so that you can re-order struct-like variants *and* the fields within those variants at the same time.

Another issue I found is the `field!` macro - the way it generates the field name is inconsistent due to limitations of the macro system (eg. `field!((_, _0), ...)` has the name `__0` when it should be `_0`). It should be possible to implement it as a procedural macro, so that one can just write `field!("_0", ...)` and not have to worry about the encoding.