### PR TITLE
Explore using proc_macro_hygiene

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ codegen-units = 1 # https://users.rust-lang.org/t/odd-benchmark-results-compiler
 members = [
     "proc-macro-helpers",
     "core",
-    "proc-macros-impl",
     "proc-macros",
     "derives",
     "laws"

--- a/core/src/path.rs
+++ b/core/src/path.rs
@@ -1,6 +1,7 @@
 //! Holds models, traits, and logic for generic traversal of models
 //!
 //! ```
+//! #![feature(proc_macro_hygiene)]
 //! #[macro_use] extern crate frunk;
 //! #[macro_use] extern crate frunk_core; // required when using custom derives
 //! # extern crate frunk_proc_macros;

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -166,9 +166,7 @@ pub fn impl_labelled_generic(input: TokenStream) -> impl ToTokens {
 
             quote! { #base_impl #ref_impl #mut_impl }
         }
-        _ => panic!(
-            "Only Structs and Enums can be turned into Labelled Generics."
-        ),
+        _ => panic!("Only Structs and Enums can be turned into Labelled Generics."),
     };
 
     tree

--- a/examples/paths.rs
+++ b/examples/paths.rs
@@ -1,9 +1,14 @@
+#![feature(proc_macro_hygiene)]
+
 #[macro_use]
-extern crate frunk; // for derives
-extern crate frunk_core; // for labelledgeneric
+extern crate frunk;
+// for derives
+extern crate frunk_core;
+// for labelledgeneric
 extern crate frunk_proc_macros;
 
-use frunk_proc_macros::path;
+use frunk_core::path::PathTraverser;
+use frunk_proc_macros::{path, Path};
 
 #[derive(LabelledGeneric)]
 struct Dog<'a> {
@@ -49,21 +54,20 @@ fn main() {
         },
     };
 
-    // generic, re-usable, composable paths
-    let dimensions_lens = path!(dimensions);
-    let height_lens = dimensions_lens + path!(height);
+    // Prints height as long as `A` has the right "shape" (e.g.
+    // has `dimensions.height: usize` and `dimension.unit: SizeUnit)
+    fn print_height<'a, A, HeightIdx, UnitIdx>(obj: &'a A) -> ()
+    where
+        &'a A: PathTraverser<Path!(dimensions.height), HeightIdx, TargetValue = &'a usize>
+            + PathTraverser<Path!(dimensions.unit), UnitIdx, TargetValue = &'a SizeUnit>,
+    {
+        println!(
+            "Height [{} {:?}]",
+            path!(dimensions.height).get(obj),
+            path!(dimensions.unit).get(obj)
+        );
+    }
 
-    // Can also use simple "dot" . chaining
-    let unit_lens = path!(dimensions.unit);
-
-    println!(
-        "Dog height: [{} {:?}]",
-        height_lens.get(&dog),
-        unit_lens.get(&dog)
-    );
-    println!(
-        "Cat height: [{} {:?}]",
-        height_lens.get(&cat),
-        unit_lens.get(&cat)
-    );
+    print_height(&dog);
+    print_height(&cat);
 }

--- a/proc-macros-impl/Cargo.toml
+++ b/proc-macros-impl/Cargo.toml
@@ -14,7 +14,6 @@ travis-ci = { repository = "lloydmeta/frunk" }
 [dependencies]
 syn = "0.15"
 quote = "0.6"
-proc-macro-hack = "0.5"
 
 [lib]
 proc-macro = true

--- a/proc-macros-impl/src/lib.rs
+++ b/proc-macros-impl/src/lib.rs
@@ -6,23 +6,22 @@
 //! Links:
 //!   1. [Source on Github](https://github.com/lloydmeta/frunk)
 //!   2. [Crates.io page](https://crates.io/crates/frunk)
+#![feature(proc_macro_hygiene)]
 
 extern crate frunk_core;
 extern crate frunk_proc_macro_helpers;
 extern crate proc_macro;
-extern crate proc_macro_hack;
 
 extern crate quote;
 extern crate syn;
 
 use frunk_proc_macro_helpers::*;
 use proc_macro::TokenStream;
-use proc_macro_hack::proc_macro_hack;
 use quote::quote;
 use syn::{parse_macro_input, Expr};
 
 /// Build a generic path that can be used for traversals
-#[proc_macro_hack]
+#[proc_macro]
 pub fn path(input: TokenStream) -> TokenStream {
     let expr = parse_macro_input!(input as Expr);
     let path_type = build_path_type(expr);
@@ -31,6 +30,19 @@ pub fn path(input: TokenStream) -> TokenStream {
             let p: #path_type = ::frunk_core::path::Path::new();
             p
         }
+    };
+    //    println!("ast: [{}]", ast);
+    TokenStream::from(ast)
+}
+
+/// Build a generic path that can be used for traversals
+#[proc_macro]
+#[allow(non_snake_case)]
+pub fn Path(input: TokenStream) -> TokenStream {
+    let expr = parse_macro_input!(input as Expr);
+    let path_type = build_path_type(expr);
+    let ast = quote! {
+        #path_type
     };
     //    println!("ast: [{}]", ast);
     TokenStream::from(ast)

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -11,18 +11,22 @@ keywords = ["Frunk", "macros"]
 [badges]
 travis-ci = { repository = "lloydmeta/frunk" }
 
-[dependencies.proc-macro-hack]
-version = "0.5"
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "0.15"
+quote = "0.6"
+
+[dependencies.frunk_proc_macro_helpers]
+path = "../proc-macro-helpers"
+default-features = false
+version = "0.0.3"
 
 [dependencies.frunk_core]
 path = "../core"
 default-features = false
 version = "0.3.0"
-
-[dependencies.frunk_proc_macros_impl]
-path = "../proc-macros-impl"
-default-features = false
-version = "0.0.3"
 
 [dev-dependencies.frunk]
 path = "../."

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -4,10 +4,11 @@
 //! # Examples
 //!
 //! ```
+//! #![feature(proc_macro_hygiene)]
 //! #[macro_use] extern crate frunk;
 //! #[macro_use] extern crate frunk_core;
 //! # extern crate frunk_proc_macros;
-//! # use frunk_proc_macros::path;
+//! # use frunk_proc_macros::{path, Path};
 //! # fn main() {
 //! #[derive(LabelledGeneric)]
 //! struct Dog<'a> {
@@ -53,8 +54,8 @@
 //! };
 //!
 //! // generic, re-usable paths
-//! let height_lens = path!(dimensions.height);
-//! let unit_lens = path!(dimensions.unit);
+//! let height_lens: Path!(dimensions.height) = path!(dimensions.height);
+//! let unit_lens: Path!(dimensions.unit) = path!(dimensions.unit);
 //!
 //! assert_eq!(*height_lens.get(&dog), 10);
 //! assert_eq!(*height_lens.get(&cat), 7);
@@ -67,80 +68,46 @@
 //! # }
 //! ```
 
-extern crate frunk_core;
-extern crate frunk_proc_macros_impl;
-extern crate proc_macro_hack;
-
-use proc_macro_hack::proc_macro_hack;
-
-/// Add one to an expression.
-#[proc_macro_hack]
-pub use frunk_proc_macros_impl::path;
+#![feature(proc_macro_hygiene)]
 
 #[cfg(test)]
-#[macro_use]
 extern crate frunk;
+extern crate frunk_core;
+extern crate frunk_proc_macro_helpers;
+extern crate proc_macro;
 
-#[cfg(test)]
-mod tests {
+extern crate quote;
+extern crate syn;
 
-    #[test]
-    fn test_path() {
-        #[derive(LabelledGeneric)]
-        struct Dog<'a> {
-            name: &'a str,
-            dimensions: Dimensions,
+use frunk_proc_macro_helpers::*;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Expr};
+
+/// Build a generic path that can be used for traversals
+#[proc_macro]
+pub fn path(input: TokenStream) -> TokenStream {
+    let expr = parse_macro_input!(input as Expr);
+    let path_type = build_path_type(expr);
+    let ast = quote! {
+        {
+            let p: #path_type = ::frunk_core::path::Path::new();
+            p
         }
+    };
+    //    println!("ast: [{}]", ast);
+    TokenStream::from(ast)
+}
 
-        #[derive(LabelledGeneric)]
-        struct Cat<'a> {
-            name: &'a str,
-            dimensions: Dimensions,
-        }
-
-        #[derive(LabelledGeneric)]
-        struct Dimensions {
-            height: usize,
-            width: usize,
-            unit: SizeUnit,
-        }
-
-        #[derive(Debug, Eq, PartialEq)]
-        enum SizeUnit {
-            Cm,
-            Inch,
-        }
-
-        let mut dog = Dog {
-            name: "Joe",
-            dimensions: Dimensions {
-                height: 10,
-                width: 5,
-                unit: SizeUnit::Inch,
-            },
-        };
-
-        let cat = Cat {
-            name: "Schmoe",
-            dimensions: Dimensions {
-                height: 7,
-                width: 3,
-                unit: SizeUnit::Cm,
-            },
-        };
-
-        // generic, re-usable, compsable paths
-        let dimensions_lens = path!(dimensions);
-        let height_lens = dimensions_lens + path!(height); // compose multiple
-        let unit_lens = path!(dimensions.unit); // dot syntax to just do the whole thing at once
-
-        assert_eq!(*height_lens.get(&dog), 10);
-        assert_eq!(*height_lens.get(&cat), 7);
-        assert_eq!(*unit_lens.get(&dog), SizeUnit::Inch);
-        assert_eq!(*unit_lens.get(&cat), SizeUnit::Cm);
-
-        // modify
-        *height_lens.get(&mut dog) = 13;
-        assert_eq!(*height_lens.get(&dog), 13);
-    }
+/// Build a generic path that can be used for traversals
+#[proc_macro]
+#[allow(non_snake_case)]
+pub fn Path(input: TokenStream) -> TokenStream {
+    let expr = parse_macro_input!(input as Expr);
+    let path_type = build_path_type(expr);
+    let ast = quote! {
+        #path_type
+    };
+    //    println!("ast: [{}]", ast);
+    TokenStream::from(ast)
 }


### PR DESCRIPTION
This allows us to use proc macros as types and functions without `proc_macro_hack`

This currently only compiles on `nightly` (`cargo +nightly $cmd`), and requires https://github.com/rust-lang/rust/issues/54727 (or  https://github.com/rust-lang/rust/pull/63931 ?) to be released on stable before being merged.

<img width="609" alt="Screen Shot 2019-08-12 at 16 33 51" src="https://user-images.githubusercontent.com/914805/62850782-03638380-bd1f-11e9-9bcb-1b366f12bd30.png">
