### PR TITLE
0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]:
 
+## [0.3.1] - 2019-12-21
+- Refactoring derives (https://github.com/lloydmeta/frunk/pull/157)
+- Add support for deriving LabelledGeneric on enums (https://github.com/lloydmeta/frunk/pull/158)
+- Added HZippable (https://github.com/lloydmeta/frunk/pull/160)
+- Add a type macro for paths (https://github.com/lloydmeta/frunk/pull/161)
+
 ## [0.3.0] - 2019-03-23
 ### Added
 - More transmogrifications supported out of the box (https://github.com/lloydmeta/frunk/pull/152)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk provides developers with a number of functional programming tools like HList, Coproduct, Generic, LabelledGeneric, Validated, Monoid, Semigroup and friends."
 license = "MIT"
@@ -18,23 +18,23 @@ time = "0.1.36"
 [dependencies.frunk_core]
 path = "core"
 default-features = false
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies.frunk_proc_macros]
 path = "proc-macros"
 default-features = false
 optional = true
-version = "0.0.3"
+version = "0.0.4"
 
 [dependencies.frunk_derives]
 path = "derives"
 default-features = false
-version = "0.3.0"
+version = "0.3.1"
 
 [dev-dependencies.frunk_laws]
 path = "laws"
 default-features = false
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies]
 serde = { version = "^1.0", optional = true, features = [ "derive" ] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_core"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk core provides developers with HList, Coproduct, LabelledGeneric and Generic"
 license = "MIT"
@@ -26,9 +26,9 @@ version = "0.3.0"
 [dev-dependencies.frunk]
 path = ".."
 default-features = false
-version = "0.3.0"
+version = "0.3.1"
 
 [dev-dependencies.frunk_proc_macros]
 path = "../proc-macros"
 default-features = false
-version = "0.0.3"
+version = "0.0.4"

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -110,7 +110,6 @@ pub trait HList: Sized {
     /// assert_eq!(<Hlist![i32, bool, f32]>::static_len(), 3);
     /// # }
     /// ```
-    #[inline]
     #[deprecated(since = "0.1.31", note = "Please use LEN instead")]
     fn static_len() -> usize;
 

--- a/core/src/indices.rs
+++ b/core/src/indices.rs
@@ -55,4 +55,4 @@ pub struct LabelledGenericTransmogIndicesWrapper<T>(PhantomData<T>);
 pub struct PluckedLabelledGenericIndicesWrapper<T>(T);
 
 /// Index type wrapper for transmogrifying through a (known) container (e.g. `Vec`).
-pub struct MappingIndicesWrapper<T>(PhantomData<(T)>);
+pub struct MappingIndicesWrapper<T>(PhantomData<T>);

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -198,12 +198,10 @@ pub trait LabelledGeneric {
     type Repr;
 
     /// Convert a value to its representation type `Repr`.
-    #[inline(always)]
     fn into(self) -> Self::Repr;
 
     /// Convert a value's labelled representation type `Repr`
     /// to the values's type.
-    #[inline(always)]
     fn from(repr: Self::Repr) -> Self;
 
     /// Convert from one type to another using a type with the same
@@ -261,7 +259,6 @@ pub trait IntoLabelledGeneric {
     type Repr;
 
     /// Convert a value to its representation type `Repr`.
-    #[inline(always)]
     fn into(self) -> Self::Repr;
 }
 
@@ -594,7 +591,6 @@ pub trait ByNameFieldPlucker<TargetKey, Index> {
     type Remainder;
 
     /// Returns a pair consisting of the value pointed to by the target key and the remainder.
-    #[inline(always)]
     fn pluck_by_name(self) -> (Field<TargetKey, Self::TargetValue>, Self::Remainder);
 }
 
@@ -726,7 +722,6 @@ pub trait Transmogrifier<Target, TransmogrifyIndexIndices> {
     /// Consume this current object and return an object of the Target type.
     ///
     /// Although similar to sculpting, transmogrifying does its job recursively.
-    #[inline(always)]
     fn transmogrify(self) -> Target;
 }
 

--- a/core/src/path.rs
+++ b/core/src/path.rs
@@ -67,7 +67,6 @@ pub trait PathTraverser<Path, Indices> {
     type TargetValue;
 
     /// Returns a pair consisting of the value pointed to by the target key and the remainder.
-    #[inline(always)]
     fn get(self) -> Self::TargetValue;
 }
 

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_derives"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "frunk_derives contains the custom derivations for certain traits in Frunk."
 license = "MIT"
@@ -21,4 +21,4 @@ quote = "0.6"
 [dependencies.frunk_proc_macro_helpers]
 path = "../proc-macro-helpers"
 default-features = false
-version = "0.0.3"
+version = "0.0.4"

--- a/laws/Cargo.toml
+++ b/laws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_laws"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "frunk_laws contains laws for algebras declared in Frunk."
 license = "MIT"
@@ -14,7 +14,7 @@ travis-ci = { repository = "lloydmeta/frunk" }
 [dependencies.frunk]
 path = ".."
 default-features = false
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies]
 quickcheck = "0.6.1"

--- a/proc-macro-helpers/Cargo.toml
+++ b/proc-macro-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_proc_macro_helpers"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Common internal functions for frunk's proc macros"
 license = "MIT"
@@ -19,4 +19,4 @@ proc-macro2 = "0.4"
 [dependencies.frunk_core]
 path = "../core"
 default-features = false
-version = "0.3.0"
+version = "0.3.1"

--- a/proc-macros-impl/Cargo.toml
+++ b/proc-macros-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_proc_macros_impl"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Proc macros inernal implementations for Frunk"
 license = "MIT"
@@ -23,9 +23,9 @@ proc-macro = true
 [dependencies.frunk_core]
 path = "../core"
 default-features = false
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies.frunk_proc_macro_helpers]
 path = "../proc-macro-helpers"
 default-features = false
-version = "0.0.3"
+version = "0.0.4"

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frunk_proc_macros"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Proc macros for Frunk"
 license = "MIT"
@@ -17,14 +17,14 @@ version = "0.5"
 [dependencies.frunk_core]
 path = "../core"
 default-features = false
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies.frunk_proc_macros_impl]
 path = "../proc-macros-impl"
 default-features = false
-version = "0.0.3"
+version = "0.0.4"
 
 [dev-dependencies.frunk]
 path = "../."
 default-features = false
-version = "0.3.0"
+version = "0.3.1"


### PR DESCRIPTION
## [0.3.1] - 2019-12-21
- Refactoring derives (https://github.com/lloydmeta/frunk/pull/157)
- Add support for deriving LabelledGeneric on enums (https://github.com/lloydmeta/frunk/pull/158)
- Added HZippable (https://github.com/lloydmeta/frunk/pull/160)
- Add a type macro for paths (https://github.com/lloydmeta/frunk/pull/161)