### PR TITLE
Fix wrong `frunk-core` reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,19 +290,19 @@ let d_user: DeletedUser = frunk::transform_from(s_user);
 
 Sometimes you need might have one data type that is "similar in shape" to another data type, but it
 is similar _recursively_ (e.g. it has fields that are structs that have fields that are a superset of
-the fields in the target type, so they are transformable recursively).  `.transform_from` can't help you 
-there because it doesn't deal with recursion, but the `Transmogrifier` can help if both are `LabelledGeneric` 
+the fields in the target type, so they are transformable recursively).  `.transform_from` can't help you
+there because it doesn't deal with recursion, but the `Transmogrifier` can help if both are `LabelledGeneric`
 by `transmogrify()`ing from one to the other.
 
-What is "transmogrifying"? In this context, it means to recursively tranform some data of type A into data 
-of type B, in a typesafe way, as long as A and B are "similarly-shaped".  In other words, as long as B's 
-fields and their subfields are subsets of A's fields and their respective subfields, then A can be turned 
+What is "transmogrifying"? In this context, it means to recursively tranform some data of type A into data
+of type B, in a typesafe way, as long as A and B are "similarly-shaped".  In other words, as long as B's
+fields and their subfields are subsets of A's fields and their respective subfields, then A can be turned
 into B.
 
 As usual, the goal with Frunk is to do this:
 * Using stable (so no specialisation, which would have been helpful, methinks)
 * Typesafe
-* No usage of `unsafe` 
+* No usage of `unsafe`
 
 Here is an example:
 
@@ -390,9 +390,9 @@ some of which may be addressed in the future:
 
 * If one of the fields is an identical type **and** derives `LabelledGeneric`,
   the compiler will tell you that it can't "infer an index" for `transmogrify()`; this
-  is because `impl`s of the `Transmogrifier` trait will clash. This may or may not 
+  is because `impl`s of the `Transmogrifier` trait will clash. This may or may not
   change in the future (perhaps if we move to a pure procedural macro powered way of doing
-  things?) 
+  things?)
 * For types that contain many multiple deeply-nested fields that require `transmogfiy()`ing,
   using this technique will likely increase your compile time.
 * If you've balked at the the compile-time errors with `transform_from` when a transform is deemed
@@ -402,18 +402,18 @@ some of which may be addressed in the future:
 For more information how Generic and Field work, check out their respective Rustdocs:
   * [Generic](https://beachape.com/frunk/frunk_core/generic/index.html)
   * [Labelled](https://beachape.com/frunk/frunk_core/labelled/index.html)
-  
+
 #### Path
 
 One of the other things that `LabelledGeneric`-deriving structs can do is be generically traversed
 using `Path` and its companion trait `PathTraverser`. In some circles, this functionality is also
 called a Lens.
 
-`Path`-based traversals are 
+`Path`-based traversals are
 * Easy to use through the procedural macro `path!` (`frunk_proc_macros`)
   * Traversing multiple levels is familiar; just use dot `.` syntax (`path!(nested.attribute.value)`)
 * Compile-time safe
-* Composable (add one to the other using `+`)  
+* Composable (add one to the other using `+`)
 * Allows you to get by value, get by reference or get by mutable reference, depending on the type
   of thing you pass it.
 
@@ -644,22 +644,22 @@ assert_eq!(combine_all(&product_nums), Product(24))
 
 ### Features
 
-Frunk comes with support for deriving [serde](https://github.com/serde-rs/serde) serializer/deserializers for its core 
+Frunk comes with support for deriving [serde](https://github.com/serde-rs/serde) serializer/deserializers for its core
 data structures. This can be enabled by adding the `serde` feature flag.
 
-For example, if you'd like to use just `frunk-core` with serde
+For example, if you'd like to use just `frunk_core` with serde
 
 ```toml
 [dependencies]
-frunk-core = { version = "$version", features = ["serde"] }
+frunk_core = { version = "$version", features = ["serde"] }
 ```
 
-Or, if you'd like to use `frunk` with serde, you need to explicitly include `frunk-core` as well
+Or, if you'd like to use `frunk` with serde, you need to explicitly include `frunk_core` as well
 
 ```toml
 [dependencies]
 frunk = { version = "$version", features = ["serde"] }
-frunk-core = { version = "$version", features = ["serde"] }
+frunk_core = { version = "$version", features = ["serde"] }
 ```
 
 ## Todo


### PR DESCRIPTION
Trying to use the `Generic` macro I stumbled upon the need to also import `frunk_core`.

Unfortunately using the suggestion specified inside the `README.md` lead me to the following error 😞

```
cargo check
    Updating crates.io index
error: no matching package named `frunk-core` found
location searched: registry `https://github.com/rust-lang/crates.io-index`
perhaps you meant: frunk_core
```
Using `frunk_core` however seems to work 😄 