### PR TITLE
Added a missing import in the Semigroup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,7 @@ Things that can be combined.
 
 ```rust
 use frunk::Semigroup;
+use frunk::semigroup::All;
 
 assert_eq!(Some(1).combine(&Some(2)), Some(3));
 


### PR DESCRIPTION
The Semigroup example is missing the following import:
`use frunk::semigroup::All;`