### PR TITLE
Make `foldl` and `foldr` take exactly same arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]:
 - [Breaking change] Rename `Hlist!` type macro to `HList!` (https://github.com/lloydmeta/frunk/issues/132)
 - [Breaking change] Remove deprecated `HList.length()` (https://github.com/lloydmeta/frunk/issues/125)
+- [Breaking change] `HFoldRightable` rework: now `HFoldRightable::foldr` does not differ from `HFoldLeftable::foldl` in **calling**, like `std::iter::DoubleEndedIterator::rfold` does not differ from `std::iter::Iterator::fold`. Note: though `foldr` **behavior** wasn't changed, all old `foldr` calls would either stop compiling or produce wrong results (https://github.com/lloydmeta/frunk/issues/171)
 
 ## [0.3.2] - 2021-04-16
 - Allow folding hlist with a single Poly (https://github.com/lloydmeta/frunk/pull/170)

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ assert_eq!(h1.into_reverse(), hlist!["hi", true]);
 let h2 = hlist![1, false, 42f32];
 let folded = h2.foldr(
     hlist![
-        |i, acc| i + acc,
-        |_, acc| if acc > 42f32 { 9000 } else { 0 },
-        |f, acc| f + acc
+        |acc, i| i + acc,
+        |acc, _| if acc > 42f32 { 9000 } else { 0 },
+        |acc, f| f + acc
     ],
     1f32
 );

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -1120,21 +1120,21 @@ where
 
 impl<F, R, H, Tail, Init> HFoldRightable<F, Init> for HCons<H, Tail>
 where
-    Tail: fn_foldr::FnHFoldRightable<F, Init>,
+    Tail: foldr_owned::HFoldRightableOwned<F, Init>,
     F: Fn(<Tail as HFoldRightable<F, Init>>::Output, H) -> R,
 {
     type Output = R;
 
     fn foldr(self, folder: F, init: Init) -> Self::Output {
-        fn_foldr::FnHFoldRightable::real_foldr(self, folder, init).0
+        foldr_owned::HFoldRightableOwned::real_foldr(self, folder, init).0
     }
 }
 
-/// [`HFoldRightable`] inner mechanics for folding with a single closure/function.
-pub mod fn_foldr {
+/// [`HFoldRightable`] inner mechanics for folding with a folder that needs to be owned.
+pub mod foldr_owned {
     use super::{HCons, HFoldRightable, HNil};
 
-    /// A real `foldr` for the folder that is a closure or a function.
+    /// A real `foldr` for the folder that must be owned to fold.
     ///
     /// Due to `HList` being a recursive struct and not linear array,
     /// the only way to fold it is recursive.
@@ -1146,23 +1146,20 @@ pub mod fn_foldr {
     ///     of the folder to the next recursive call.
     /// 2. `foldr` passes the ownership of the folder to the next recursive call,
     ///     and then tries to call `folder(head)`; but the ownership is already gone!
-    ///
-    /// Thus, it should either take a reference to the folder or return ownership back.
-    /// This trait does the latter to avoid lifetimes in the trait definition.
-    pub trait FnHFoldRightable<Folder, Init>: HFoldRightable<Folder, Init> {
+    pub trait HFoldRightableOwned<Folder, Init>: HFoldRightable<Folder, Init> {
         fn real_foldr(self, folder: Folder, init: Init) -> (Self::Output, Folder);
     }
 
-    impl<F, Init> FnHFoldRightable<F, Init> for HNil {
+    impl<F, Init> HFoldRightableOwned<F, Init> for HNil {
         fn real_foldr(self, f: F, i: Init) -> (Self::Output, F) {
             (i, f)
         }
     }
 
-    impl<F, H, Tail, Init> FnHFoldRightable<F, Init> for HCons<H, Tail>
+    impl<F, H, Tail, Init> HFoldRightableOwned<F, Init> for HCons<H, Tail>
     where
         Self: HFoldRightable<F, Init>,
-        Tail: FnHFoldRightable<F, Init>,
+        Tail: HFoldRightableOwned<F, Init>,
         F: Fn(<Tail as HFoldRightable<F, Init>>::Output, H) -> Self::Output,
     {
         fn real_foldr(self, folder: F, init: Init) -> (Self::Output, F) {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,9 +13,9 @@
 //! # fn main() {
 //!
 //! let h = hlist![1, false, 42f32];
-//! let folded = h.foldr(hlist![|i, acc| i + acc,
-//!     |_, acc| if acc > 42f32 { 9000 } else { 0 },
-//!     |f, acc| f + acc],
+//! let folded = h.foldr(hlist![|acc, i| i + acc,
+//!     |acc, _| if acc > 42f32 { 9000 } else { 0 },
+//!     |acc, f| f + acc],
 //!     1f32);
 //! assert_eq!(folded, 9001);
 //!
@@ -26,9 +26,9 @@
 //! // foldr (foldl also available)
 //! let h2 = hlist![1, false, 42f32];
 //! let folded = h2.foldr(
-//!             hlist![|i, acc| i + acc,
-//!                    |_, acc| if acc > 42f32 { 9000 } else { 0 },
-//!                    |f, acc| f + acc],
+//!             hlist![|acc, i| i + acc,
+//!                    |acc, _| if acc > 42f32 { 9000 } else { 0 },
+//!                    |acc, f| f + acc],
 //!             1f32
 //!     );
 //! assert_eq!(folded, 9001);


### PR DESCRIPTION
Closes #171.

Unresolved question: do we want [dirty hacks](https://github.com/lloydmeta/frunk/issues/171#issuecomment-812454214) to completely unify `foldl` and `foldr` arguments?