### PR TITLE
0.4 cleanup: rename HList type macro, remove HList#length()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]:
+- [Breaking change] Rename `Hlist!` type macro to `HList!` (https://github.com/lloydmeta/frunk/issues/132)
+- [Breaking change] Remove deprecated `HList.length()` (https://github.com/lloydmeta/frunk/issues/125)
 
 ## [0.3.2] - 2021-04-16
 - Allow folding hlist with a single Poly (https://github.com/lloydmeta/frunk/pull/170)

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ let t: (f32, bool, &str) = h2.into();
 assert_eq!(t, (42f32, true, "hello"));
 
 let t3 = (999, false, "world");
-let h3: Hlist![ isize, bool, &str ] = t3.into();
+let h3: HList![ isize, bool, &str ] = t3.into();
 assert_eq!(h3, hlist![ 999, false, "world" ]);
 ```
 
 HLists have a `hlist_pat!` macro for pattern matching;
 ```rust
-let h: Hlist!(&str, &str, i32, bool) = hlist!["Joe", "Blow", 30, true];
-// We use the Hlist! type macro to make it easier to write
+let h: HList!(&str, &str, i32, bool) = hlist!["Joe", "Blow", 30, true];
+// We use the HList! type macro to make it easier to write
 // a type signature for HLists, which is a series of nested HCons
 // h has an expanded static type of: HCons<&str, HCons<&str, HCons<i32, HCons<bool, HNil>>>>
 
@@ -153,7 +153,7 @@ must be a subset of the types in the original `HList`.
 
 ```rust
 let h = hlist![9000, "joe", 41f32, true];
-let (reshaped, remainder): (Hlist![f32, i32, &str], _) = h.sculpt();
+let (reshaped, remainder): (HList![f32, i32, &str], _) = h.sculpt();
 assert_eq!(reshaped, hlist![41f32, 9000, "joe"]);
 assert_eq!(remainder, hlist![true]);
 ```
@@ -712,3 +712,4 @@ A.k.a. people whom you can bug/tag/@ on Gitter :D
 
 1. [lloydmeta](https://github.com/lloydmeta)
 2. [Centril](https://github.com/centril)
+3. [ExpHP](https://github.com/ExpHP)

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -79,11 +79,6 @@ pub trait HList: Sized {
     /// ```
     const LEN: usize;
 
-    #[deprecated(since = "0.1.30", note = "Please use len() or static_len() instead.")]
-    fn length(&self) -> u32 {
-        Self::LEN as u32
-    }
-
     /// Returns the length of a given HList
     ///
     /// # Examples

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -50,7 +50,7 @@
 //!
 //! // Resculpting an HList
 //! let h5 = hlist![9000, "joe", 41f32, true];
-//! let (reshaped, remainder2): (Hlist![f32, i32, &str], _) = h5.sculpt();
+//! let (reshaped, remainder2): (HList![f32, i32, &str], _) = h5.sculpt();
 //! assert_eq!(reshaped, hlist![41f32, 9000, "joe"]);
 //! assert_eq!(remainder2, hlist![true]);
 //! # }
@@ -74,7 +74,7 @@ pub trait HList: Sized {
     /// # #[macro_use] extern crate frunk; fn main() {
     /// use frunk::prelude::*;
     ///
-    /// assert_eq!(<Hlist![i32, bool, f32]>::LEN, 3);
+    /// assert_eq!(<HList![i32, bool, f32]>::LEN, 3);
     /// # }
     /// ```
     const LEN: usize;
@@ -122,7 +122,7 @@ pub trait HList: Sized {
     /// # #[macro_use] extern crate frunk; fn main() {
     /// use frunk::prelude::*;
     ///
-    /// assert_eq!(<Hlist![i32, bool, f32]>::static_len(), 3);
+    /// assert_eq!(<HList![i32, bool, f32]>::static_len(), 3);
     /// # }
     /// ```
     #[deprecated(since = "0.1.31", note = "Please use LEN instead")]
@@ -297,7 +297,7 @@ macro_rules! gen_inherent_methods {
             /// ```
             /// # #[macro_use] extern crate frunk; fn main() {
             /// let h = hlist![9000, "joe", 41f32, true];
-            /// let (reshaped, remainder): (Hlist![f32, i32, &str], _) = h.sculpt();
+            /// let (reshaped, remainder): (HList![f32, i32, &str], _) = h.sculpt();
             /// assert_eq!(reshaped, hlist![41f32, 9000, "joe"]);
             /// assert_eq!(remainder, hlist![true]);
             /// # }
@@ -371,8 +371,8 @@ macro_rules! gen_inherent_methods {
 
             /// Apply a function to each element of an HList.
             ///
-            /// This transforms some `Hlist![A, B, C, ..., E]` into some
-            /// `Hlist![T, U, V, ..., Z]`.  A variety of types are supported
+            /// This transforms some `HList![A, B, C, ..., E]` into some
+            /// `HList![T, U, V, ..., Z]`.  A variety of types are supported
             /// for the folder argument:
             ///
             /// * An `hlist![]` of closures (one for each element).
@@ -418,8 +418,8 @@ macro_rules! gen_inherent_methods {
 
             /// Zip two HLists together.
             ///
-            /// This zips a `Hlist![A1, B1, ..., C1]` with a `Hlist![A2, B2, ..., C2]`
-            /// to make a `Hlist![(A1, A2), (B1, B2), ..., (C1, C2)]`
+            /// This zips a `HList![A1, B1, ..., C1]` with a `HList![A2, B2, ..., C2]`
+            /// to make a `HList![(A1, A2), (B1, B2), ..., (C1, C2)]`
             ///
             /// # Example
             ///
@@ -449,7 +449,7 @@ macro_rules! gen_inherent_methods {
 
             /// Perform a left fold over an HList.
             ///
-            /// This transforms some `Hlist![A, B, C, ..., E]` into a single
+            /// This transforms some `HList![A, B, C, ..., E]` into a single
             /// value by visiting all of the elements in left-to-right order.
             /// A variety of types are supported for the mapper argument:
             ///
@@ -522,7 +522,7 @@ macro_rules! gen_inherent_methods {
 
             /// Perform a right fold over an HList.
             ///
-            /// This transforms some `Hlist![A, B, C, ..., E]` into a single
+            /// This transforms some `HList![A, B, C, ..., E]` into a single
             /// value by visiting all of the elements in reverse order.
             /// A variety of types are supported for the mapper argument:
             ///
@@ -1379,7 +1379,7 @@ impl<T: Default, Tail: Default + HList> Default for HCons<T, Tail> {
 /// use frunk::lift_from;
 /// use frunk::prelude::*;
 ///
-/// type H = Hlist![(), usize, f64, (), bool];
+/// type H = HList![(), usize, f64, (), bool];
 ///
 /// let x = H::lift_from(42.0);
 /// assert_eq!(x, hlist![(), 0, 42.0, (), false]);
@@ -1406,7 +1406,7 @@ pub fn lift_from<I, T, PF: LiftFrom<T, I>>(part: T) -> PF {
 /// # #[macro_use] extern crate frunk; fn main() {
 /// use frunk::prelude::*;
 ///
-/// type H = Hlist![(), usize, f64, (), bool];
+/// type H = HList![(), usize, f64, (), bool];
 ///
 /// // Type inference works as expected:
 /// let x: H = 1337.lift_into();
@@ -1508,7 +1508,7 @@ mod tests {
     #[test]
     fn test_hlist_macro() {
         assert_eq!(hlist![], HNil);
-        let h: Hlist!(i32, &str, i32) = hlist![1, "2", 3];
+        let h: HList!(i32, &str, i32) = hlist![1, "2", 3];
         let (h1, tail1) = h.pop();
         assert_eq!(h1, 1);
         assert_eq!(tail1, hlist!["2", 3]);
@@ -1523,10 +1523,10 @@ mod tests {
     #[test]
     #[allow(non_snake_case)]
     fn test_Hlist_macro() {
-        let h1: Hlist!(i32, &str, i32) = hlist![1, "2", 3];
-        let h2: Hlist!(i32, &str, i32,) = hlist![1, "2", 3];
-        let h3: Hlist!(i32) = hlist![1];
-        let h4: Hlist!(i32,) = hlist![1,];
+        let h1: HList!(i32, &str, i32) = hlist![1, "2", 3];
+        let h2: HList!(i32, &str, i32,) = hlist![1, "2", 3];
+        let h3: HList!(i32) = hlist![1];
+        let h4: HList!(i32,) = hlist![1,];
         assert_eq!(h1, h2);
         assert_eq!(h3, h4);
     }
@@ -1794,14 +1794,14 @@ mod tests {
     #[test]
     fn test_sculpt() {
         let h = hlist![9000, "joe", 41f32];
-        let (reshaped, remainder): (Hlist!(f32, i32), _) = h.sculpt();
+        let (reshaped, remainder): (HList!(f32, i32), _) = h.sculpt();
         assert_eq!(reshaped, hlist![41f32, 9000]);
         assert_eq!(remainder, hlist!["joe"])
     }
 
     #[test]
     fn test_len_const() {
-        assert_eq!(<Hlist![usize, &str, f32] as HList>::LEN, 3);
+        assert_eq!(<HList![usize, &str, f32] as HList>::LEN, 3);
     }
 
     #[test]
@@ -1854,7 +1854,7 @@ mod tests {
 
     #[test]
     fn test_lift() {
-        type H = Hlist![(), usize, f64, (), bool];
+        type H = HList![(), usize, f64, (), bool];
 
         // Ensure type inference works as expected first:
         let x: H = 1337.lift_into();

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -542,7 +542,7 @@ pub trait IntoValueLabelled {
     ///     field!((a, g, e), 3)
     /// ];
     /// // Notice the lack of type-level names
-    /// let value_labelled: Hlist![ValueField<&str>, ValueField<isize>] = labelled_hlist.into_value_labelled();
+    /// let value_labelled: HList![ValueField<&str>, ValueField<isize>] = labelled_hlist.into_value_labelled();
     ///
     /// assert_eq!(
     ///   value_labelled,
@@ -984,7 +984,7 @@ mod tests {
     #[test]
     fn test_value_labelling() {
         let labelled_hlist = hlist![field!(name, "joe"), field!((a, g, e), 3)];
-        let value_labelled: Hlist![ValueField<&str>, ValueField<isize>] =
+        let value_labelled: HList![ValueField<&str>, ValueField<isize>] =
             labelled_hlist.into_value_labelled();
         let hlist_pat!(f1, f2) = value_labelled;
         assert_eq!(f1.name, "name");
@@ -1005,8 +1005,8 @@ mod tests {
 
     #[test]
     fn test_transmogrify_hcons_sculpting_super_simple() {
-        type Source = Hlist![Field<name, &'static str>, Field<age, i32>, Field<is_admin, bool>];
-        type Target = Hlist![Field<age, i32>];
+        type Source = HList![Field<name, &'static str>, Field<age, i32>, Field<is_admin, bool>];
+        type Target = HList![Field<age, i32>];
         let hcons: Source = hlist!(field!(name, "joe"), field!(age, 3), field!(is_admin, true));
         let t_hcons: Target = hcons.transmogrify();
         assert_eq!(t_hcons, hlist!(field!(age, 3)));
@@ -1014,8 +1014,8 @@ mod tests {
 
     #[test]
     fn test_transmogrify_hcons_sculpting_somewhat_simple() {
-        type Source = Hlist![Field<name, &'static str>, Field<age, i32>, Field<is_admin, bool>];
-        type Target = Hlist![Field<is_admin, bool>, Field<name, &'static str>];
+        type Source = HList![Field<name, &'static str>, Field<age, i32>, Field<is_admin, bool>];
+        type Target = HList![Field<is_admin, bool>, Field<name, &'static str>];
         let hcons: Source = hlist!(field!(name, "joe"), field!(age, 3), field!(is_admin, true));
         let t_hcons: Target = hcons.transmogrify();
         assert_eq!(t_hcons, hlist!(field!(is_admin, true), field!(name, "joe")));
@@ -1023,16 +1023,16 @@ mod tests {
 
     #[test]
     fn test_transmogrify_hcons_recursive_simple() {
-        type Source = Hlist![
-            Field<name,  Hlist![
+        type Source = HList![
+            Field<name,  HList![
                 Field<inner, f32>,
                 Field<is_admin, bool>,
             ]>,
             Field<age, i32>,
             Field<is_admin, bool>];
-        type Target = Hlist![
+        type Target = HList![
             Field<is_admin, bool>,
-            Field<name,  Hlist![
+            Field<name,  HList![
                 Field<is_admin, bool>,
             ]>,
         ];
@@ -1053,8 +1053,8 @@ mod tests {
 
     #[test]
     fn test_transmogrify_hcons_sculpting_required_simple() {
-        type Source = Hlist![Field<name, &'static str>, Field<age, i32>, Field<is_admin, bool>];
-        type Target = Hlist![Field<is_admin, bool>, Field<name, &'static str>, Field<age, i32>];
+        type Source = HList![Field<name, &'static str>, Field<age, i32>, Field<is_admin, bool>];
+        type Target = HList![Field<is_admin, bool>, Field<name, &'static str>, Field<age, i32>];
         let hcons: Source = hlist!(field!(name, "joe"), field!(age, 3), field!(is_admin, true));
         let t_hcons: Target = hcons.transmogrify();
         assert_eq!(
@@ -1065,7 +1065,7 @@ mod tests {
 
     #[test]
     fn test_transmogrify_identical_transform_labelled_fields() {
-        type Source = Hlist![
+        type Source = HList![
             Field<name,  &'static str>,
             Field<age, i32>,
             Field<is_admin, bool>
@@ -1081,19 +1081,19 @@ mod tests {
 
     #[test]
     fn test_transmogrify_through_containers() {
-        type SourceOuter<T> = Hlist![
+        type SourceOuter<T> = HList![
             Field<name, &'static str>,
             Field<inner, T>,
         ];
-        type SourceInner = Hlist![
+        type SourceInner = HList![
             Field<is_admin, bool>,
             Field<age, i32>,
         ];
-        type TargetOuter<T> = Hlist![
+        type TargetOuter<T> = HList![
             Field<name, &'static str>,
             Field<inner, T>,
         ];
-        type TargetInner = Hlist![
+        type TargetInner = HList![
             Field<age, i32>,
             Field<is_admin, bool>,
         ];
@@ -1185,8 +1185,8 @@ mod tests {
 
     //    #[test]
     //    fn test_transmogrify_identical_transform_nested_labelled_fields() {
-    //        type Source = Hlist![
-    //    Field<name,  Hlist![
+    //        type Source = HList![
+    //    Field<name,  HList![
     //        Field<inner, f32>,
     //        Field<is_admin, bool>,
     //    ]>,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! // Resculpting an HList
 //! let h5 = hlist![9000, "joe", 41f32, true];
-//! let (reshaped, remainder2): (Hlist![f32, i32, &str], _) = h5.sculpt();
+//! let (reshaped, remainder2): (HList![f32, i32, &str], _) = h5.sculpt();
 //! assert_eq!(reshaped, hlist![41f32, 9000, "joe"]);
 //! assert_eq!(remainder2, hlist![true]);
 //! # }

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -86,19 +86,19 @@ macro_rules! hlist_pat {
 ///
 /// ```
 /// # #[macro_use] extern crate frunk; fn main() {
-/// let h: Hlist!(f32, &str, Option<i32>) = hlist![13.5f32, "hello", Some(41)];
+/// let h: HList!(f32, &str, Option<i32>) = hlist![13.5f32, "hello", Some(41)];
 ///
 /// // Use "...Tail" to append another HList type at the end.
-/// let h: Hlist!(f32, ...Hlist!(&str, Option<i32>)) = hlist![13.5f32, "hello", Some(41)];
+/// let h: HList!(f32, ...HList!(&str, Option<i32>)) = hlist![13.5f32, "hello", Some(41)];
 /// # }
 /// ```
 #[macro_export]
-macro_rules! Hlist {
+macro_rules! HList {
     () => { $crate::hlist::HNil };
     (...$Rest:ty) => { $Rest };
-    ($A:ty) => { $crate::Hlist![$A,] };
+    ($A:ty) => { $crate::HList![$A,] };
     ($A:ty, $($tok:tt)*) => {
-        $crate::hlist::HCons<$A, $crate::Hlist![$($tok)*]>
+        $crate::hlist::HCons<$A, $crate::HList![$($tok)*]>
     };
 }
 
@@ -301,11 +301,11 @@ mod tests {
     fn trailing_commas() {
         use test_structs::unit_copy::{A, B};
 
-        let hlist_pat![]: Hlist![] = hlist![];
-        let hlist_pat![A]: Hlist![A] = hlist![A];
-        let hlist_pat![A,]: Hlist![A,] = hlist![A,];
-        let hlist_pat![A, B]: Hlist![A, B] = hlist![A, B];
-        let hlist_pat![A, B,]: Hlist![A, B,] = hlist![A, B,];
+        let hlist_pat![]: HList![] = hlist![];
+        let hlist_pat![A]: HList![A] = hlist![A];
+        let hlist_pat![A,]: HList![A,] = hlist![A,];
+        let hlist_pat![A, B]: HList![A, B] = hlist![A, B];
+        let hlist_pat![A, B,]: HList![A, B,] = hlist![A, B,];
 
         let falsum = || false;
         if falsum() {
@@ -331,9 +331,9 @@ mod tests {
         use test_structs::unit_copy::{A, B, C};
 
         // hlist: accepted locations, and consistency between macros
-        let hlist_pat![...hlist_pat![C]]: Hlist![...Hlist![C]] = { hlist![...hlist![C]] };
-        let hlist_pat![A, ...hlist_pat![C]]: Hlist![A, ...Hlist![C]] = { hlist![A, ...hlist![C]] };
-        let hlist_pat![A, B, ...hlist_pat![C]]: Hlist![A, B, ...Hlist![C]] =
+        let hlist_pat![...hlist_pat![C]]: HList![...HList![C]] = { hlist![...hlist![C]] };
+        let hlist_pat![A, ...hlist_pat![C]]: HList![A, ...HList![C]] = { hlist![A, ...hlist![C]] };
+        let hlist_pat![A, B, ...hlist_pat![C]]: HList![A, B, ...HList![C]] =
             { hlist![A, B, ...hlist![C]] };
 
         // hlist: ellipsis semantics

--- a/core/src/tuples.rs
+++ b/core/src/tuples.rs
@@ -9,7 +9,7 @@
 //! assert_eq!(t, (42f32, true, "hello"));
 //!
 //! let t2 = (999, false, "world");
-//! let h2: Hlist![ isize, bool, &str ] = t2.into();
+//! let h2: HList![ isize, bool, &str ] = t2.into();
 //! assert_eq!(h2, hlist![ 999, false, "world" ]);
 //! # }
 //! ```
@@ -28,7 +28,7 @@ macro_rules! tup_def {
                 $fone , $sone:  From<$fone> ,
               $($ftype, $stype: From<$ftype>,)*
         > From< ( $fone, $( $ftype, )* ) >
-        for Hlist![$( $dtype, )* $sone, $( $stype, )* ] {
+        for HList![$( $dtype, )* $sone, $( $stype, )* ] {
             fn from(f: ( $fone, $( $ftype, )* )) -> Self {
                 #[allow(non_snake_case)]
                 let ( $fone, $( $ftype, )* ) = f;
@@ -41,17 +41,17 @@ macro_rules! tup_def {
 macro_rules! tup_iso {
     ( $t: ident ) => {
         impl<$t> Generic for ($t,) {
-            type Repr = Hlist![$t];
+            type Repr = HList![$t];
             fn into(self) -> Self::Repr { hlist![self.0] }
             fn from(r: Self::Repr) -> Self { (r.head,) }
         }
 
-        impl<$t> From<($t,)> for Hlist![$t] {
+        impl<$t> From<($t,)> for HList![$t] {
             fn from(tup: ($t,)) -> Self { Generic::into(tup) }
         }
 
         #[allow(clippy::from_over_into)]
-        impl<$t> Into<($t,)> for Hlist![$t] {
+        impl<$t> Into<($t,)> for HList![$t] {
             fn into(self) -> ($t,) { Generic::from(self) }
         }
     };
@@ -60,7 +60,7 @@ macro_rules! tup_iso {
         tup_iso!($( $type ),*);
 
         impl<$type1, $($type),*> Generic for ($type1, $($type),*,) {
-            type Repr = Hlist![$type1, $($type),*,];
+            type Repr = HList![$type1, $($type),*,];
 
             fn into(self) -> Self::Repr {
                 #[allow(non_snake_case)]
@@ -76,7 +76,7 @@ macro_rules! tup_iso {
         }
 
         impl<$type1, $($type),*> From< ( $type1, $($type),*, ) >
-        for Hlist![ $type1, $($type),*, ] {
+        for HList![ $type1, $($type),*, ] {
             fn from(tup: ( $type1, $( $type ),*, ) ) -> Self {
                 Generic::into(tup)
             }
@@ -84,7 +84,7 @@ macro_rules! tup_iso {
 
         #[allow(clippy::from_over_into)]
         impl< $type1, $($type),*> Into< ( $type1, $($type),*, ) >
-        for Hlist![ $type1, $($type),*, ] {
+        for HList![ $type1, $($type),*, ] {
             fn into(self) -> ( $type1, $( $type ),*, ) {
                 Generic::from(self)
             }
@@ -93,14 +93,14 @@ macro_rules! tup_iso {
 }
 
 impl Generic for () {
-    type Repr = Hlist![];
+    type Repr = HList![];
     fn into(self) -> Self::Repr {
         hlist![]
     }
     fn from(_: Self::Repr) -> Self {}
 }
 
-impl From<()> for Hlist![] {
+impl From<()> for HList![] {
     fn from(_: ()) -> Self {
         hlist![]
     }

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -125,10 +125,8 @@ pub fn combine_all_option<T>(xs: &[T]) -> Option<T>
 where
     T: Semigroup + Clone,
 {
-    match xs.first() {
-        Some(head) => Some(xs[1..].iter().fold(head.clone(), |a, b| a.combine(b))),
-        _ => None,
-    }
+    xs.first()
+        .map(|head| xs[1..].iter().fold(head.clone(), |a, b| a.combine(b)))
 }
 
 macro_rules! numeric_semigroup_imps {

--- a/src/validated.rs
+++ b/src/validated.rs
@@ -29,7 +29,7 @@
 //!     Result::Ok(32)
 //! }
 //!
-//! let v: Validated<Hlist!(String, i32), String> = get_name().into_validated() + get_age();
+//! let v: Validated<HList!(String, i32), String> = get_name().into_validated() + get_age();
 //! let person = v.into_result()
 //!                .map(|hlist_pat!(name, age)| {
 //!                     Person {

--- a/tests/macro_tests.rs
+++ b/tests/macro_tests.rs
@@ -9,7 +9,7 @@ extern crate frunk;
 fn use_frunk_macros() {
     let h1 = hlist![1i32, 2u32];
     let h2 = hlist!["cool", ...h1];
-    let hlist_pat![a, ...bs]: Hlist![&'static str, i32, ...Hlist![u32]] = h2;
+    let hlist_pat![a, ...bs]: HList![&'static str, i32, ...HList![u32]] = h2;
     assert_eq!(a, "cool");
     assert_eq!(bs, h1);
 }


### PR DESCRIPTION
Adding some more breaking changes in prep for 0.4 as mentioned in https://github.com/lloydmeta/frunk/pull/178#issuecomment-826321458

Closes https://github.com/lloydmeta/frunk/issues/125
Closes https://github.com/lloydmeta/frunk/issues/132