### PR TITLE
Bump quote, syn and proc-macro2 to 1

### DIFF
--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -15,8 +15,8 @@ travis-ci = { repository = "lloydmeta/frunk" }
 proc-macro = true
 
 [dependencies]
-syn = "0.15"
-quote = "0.6"
+syn = "1"
+quote = "1"
 
 [dependencies.frunk_proc_macro_helpers]
 path = "../proc-macro-helpers"

--- a/proc-macro-helpers/Cargo.toml
+++ b/proc-macro-helpers/Cargo.toml
@@ -12,9 +12,9 @@ keywords = ["Frunk", "macros", "internal"]
 travis-ci = { repository = "lloydmeta/frunk" }
 
 [dependencies]
-syn = "0.15"
-quote = "0.6"
-proc-macro2 = "0.4"
+syn = "1"
+quote = "1"
+proc-macro2 = "1"
 
 [dependencies.frunk_core]
 path = "../core"

--- a/proc-macro-helpers/src/lib.rs
+++ b/proc-macro-helpers/src/lib.rs
@@ -16,9 +16,8 @@ extern crate quote;
 extern crate syn;
 
 use proc_macro::TokenStream;
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::ToTokens;
-use quote::__rt::Span;
 use syn::spanned::Spanned;
 use syn::{
     DeriveInput, Expr, Field, Fields, GenericParam, Generics, Ident, Lifetime, LifetimeDef, Member,

--- a/proc-macros-impl/Cargo.toml
+++ b/proc-macros-impl/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["Frunk", "macros", "internal"]
 travis-ci = { repository = "lloydmeta/frunk" }
 
 [dependencies]
-syn = "0.15"
-quote = "0.6"
+syn = "1"
+quote = "1"
 proc-macro-hack = "0.5"
 
 [lib]


### PR DESCRIPTION
Bumps `quote`, `syn` and `proc-macro2` dependencies of Frunk's proc macro crates to `1`.

I'm working on a procedural macro where I want to use some public functions from the  Frunk procedural macro crates, but the function argument types are incompatible with version 1 of the `quote`, `syn` and `proc-macro2` dependencies.
Updating these dependencies is a breaking change for the users of these crates.

Thanks for this awesome crate!