### PR TITLE
Optimize Semigroup for HashSet and HashMap

### DIFF
--- a/proc-macro-helpers/src/lib.rs
+++ b/proc-macro-helpers/src/lib.rs
@@ -176,7 +176,7 @@ pub fn build_path_type(path_expr: Expr) -> impl ToTokens {
     let idents = find_idents_in_expr(path_expr);
     idents
         .iter()
-        .map(|i| build_label_type(i))
+        .map(build_label_type)
         .fold(quote!(::frunk_core::hlist::HNil), |acc, t| {
             quote! {
             ::frunk_core::path::Path<

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -231,10 +231,7 @@ where
     V: Semigroup + Clone,
 {
     fn combine(&self, other: &Self) -> Self {
-        let mut h: HashMap<K, V> = HashMap::new();
-        for (k, v) in self {
-            h.insert(k.clone(), v.clone());
-        }
+        let mut h: HashMap<K, V> = self.clone();
         for (k, v) in other {
             let k_clone = k.clone();
             match h.entry(k_clone) {

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -162,11 +162,9 @@ where
     T: Semigroup + Clone,
 {
     fn combine(&self, other: &Self) -> Self {
-        match *self {
-            Some(ref v) => match *other {
-                Some(ref v_other) => Some(v.combine(v_other)),
-                _ => self.clone(),
-            },
+        match (self, other) {
+            (Some(ref v), Some(ref v_other)) => Some(v.combine(v_other)),
+            (Some(_), _) => self.clone(),
             _ => other.clone(),
         }
     }

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -220,14 +220,7 @@ where
     T: Eq + Hash + Clone,
 {
     fn combine(&self, other: &Self) -> Self {
-        let mut h = HashSet::new();
-        for i in self {
-            h.insert(i.clone());
-        }
-        for i in other {
-            h.insert(i.clone());
-        }
-        h
+        self.union(other).cloned().collect()
     }
 }
 


### PR DESCRIPTION
- Optimize Semigroup for HashSet (union is faster)
- Optimize Semigroup for HashMap (HashMap::clone is optimized)
- Prettify code in Semigroup for Option
