### PR TITLE
Optimized memory layout for Coproducts

### DIFF
--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -410,8 +410,8 @@ impl<Untagged> Coproduct<Untagged> {
     /// let co2_nice: I32F32 = Coproduct::inject(42f32);
     ///
     /// // Compare this to the "hard way":
-    /// let co1_ugly: I32F32 = Coproduct::Inl(1i32);
-    /// let co2_ugly: I32F32 = Coproduct::Inr(Coproduct::Inl(42f32));
+    /// let co1_ugly: I32F32 = Coproduct::here(1i32);
+    /// let co2_ugly: I32F32 = Coproduct::there(Coproduct::here(42f32));
     ///
     /// assert_eq!(co1_nice, co1_ugly);
     /// assert_eq!(co2_nice, co2_ugly);
@@ -588,7 +588,7 @@ impl<Head, Tail> Coproduct<UntaggedCoproduct<Head, Tail>> {
     ///     };
     ///
     ///     // Now co is empty
-    ///     match co { /* unreachable */ }
+    ///     match frunk::coproduct::absurd(co) {}
     /// }
     ///
     /// assert_eq!(handle_i32_f32(I32F32::inject(3)), "integer!");
@@ -708,7 +708,7 @@ impl<Untagged> Coproduct<Untagged> {
     ///     };
     ///
     ///     // Now co is empty.
-    ///     match co { /* unreachable */ }
+    ///     match frunk::coproduct::absurd(co) {}
     /// }
     ///
     /// assert_eq!(handle_all(Coproduct::inject("hello")), "&str hello");
@@ -770,7 +770,7 @@ impl<Untagged> Coproduct<Untagged> {
     ///
     /// // Turbofish syntax for specifying the output type is also supported.
     /// // The Indices parameter should be left to type inference using `_`.
-    /// let embedded = co.embed::<I32BoolF32, _>();
+    /// let embedded = co.embed::<<I32BoolF32 as frunk::coproduct::Untagger>::Untagged, _>();
     /// assert_eq!(embedded, I32BoolF32::inject(true));
     /// # }
     /// ```

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -244,7 +244,7 @@ impl<T> Untagger for Coproduct<T> {
     type Untagged = T;
 }
 
-impl<Untagged: IndexedClone> Clone for Coproduct<Untagged> {
+impl<T: IndexedClone> Clone for Coproduct<T> {
     fn clone(&self) -> Self {
         Self {
             tag: self.tag,
@@ -276,6 +276,16 @@ impl IndexedClone for CNil {
         match *self {}
     }
 }
+
+impl<H: Copy, T: Copy> Clone for UntaggedCoproduct<H, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<H: Copy, T: Copy> Copy for UntaggedCoproduct<H, T> {}
+
+impl<Untagged: Copy + IndexedClone> Copy for Coproduct<Untagged> {}
 
 impl<H: PartialEq, T: Comparer> PartialEq for Coproduct<UntaggedCoproduct<H, T>> {
     fn eq(&self, other: &Self) -> bool {
@@ -1258,22 +1268,22 @@ mod tests {
         let co2 = I32StrBool::inject("hello");
         let co3 = I32StrBool::inject(false);
 
-        let uninject_i32_co1: Result<i32, _> = co1.clone().uninject();
-        let uninject_str_co1: Result<&'static str, _> = co1.clone().uninject();
+        let uninject_i32_co1: Result<i32, _> = co1.uninject();
+        let uninject_str_co1: Result<&'static str, _> = co1.uninject();
         let uninject_bool_co1: Result<bool, _> = co1.uninject();
         assert_eq!(uninject_i32_co1, Ok(3));
         assert!(uninject_str_co1.is_err());
         assert!(uninject_bool_co1.is_err());
 
-        let uninject_i32_co2: Result<i32, _> = co2.clone().uninject();
-        let uninject_str_co2: Result<&'static str, _> = co2.clone().uninject();
+        let uninject_i32_co2: Result<i32, _> = co2.uninject();
+        let uninject_str_co2: Result<&'static str, _> = co2.uninject();
         let uninject_bool_co2: Result<bool, _> = co2.uninject();
         assert!(uninject_i32_co2.is_err());
         assert_eq!(uninject_str_co2, Ok("hello"));
         assert!(uninject_bool_co2.is_err());
 
-        let uninject_i32_co3: Result<i32, _> = co3.clone().uninject();
-        let uninject_str_co3: Result<&'static str, _> = co3.clone().uninject();
+        let uninject_i32_co3: Result<i32, _> = co3.uninject();
+        let uninject_str_co3: Result<&'static str, _> = co3.uninject();
         let uninject_bool_co3: Result<bool, _> = co3.uninject();
         assert!(uninject_i32_co3.is_err());
         assert!(uninject_str_co3.is_err());

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -97,15 +97,15 @@ pub union UntaggedCoproduct<H, T> {
 pub enum CNil {}
 
 pub trait IndexedDrop {
-    fn idrop(&mut self, i: usize);
+    fn idrop(&mut self, i: u32);
 }
 
 impl IndexedDrop for CNil {
-    fn idrop(&mut self, _: usize) {}
+    fn idrop(&mut self, _: u32) {}
 }
 
 impl<H, T: IndexedDrop> IndexedDrop for UntaggedCoproduct<H, T> {
-    fn idrop(&mut self, i: usize) {
+    fn idrop(&mut self, i: u32) {
         if i == 0 {
             unsafe { ManuallyDrop::drop(&mut self.head) }
         } else {
@@ -219,7 +219,7 @@ where
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Coproduct<Untagged> {
-    tag: usize,
+    tag: u32,
     untagged: Untagged,
 }
 
@@ -254,11 +254,11 @@ impl<T: IndexedClone> Clone for Coproduct<T> {
 }
 
 trait IndexedClone {
-    fn iclone(&self, i: usize) -> Self;
+    fn iclone(&self, i: u32) -> Self;
 }
 
 impl<H: Clone, T: IndexedClone> IndexedClone for UntaggedCoproduct<H, T> {
-    fn iclone(&self, i: usize) -> Self {
+    fn iclone(&self, i: u32) -> Self {
         if i == 0 {
             UntaggedCoproduct {
                 head: unsafe { &self.head }.clone(),
@@ -272,7 +272,7 @@ impl<H: Clone, T: IndexedClone> IndexedClone for UntaggedCoproduct<H, T> {
 }
 
 impl IndexedClone for CNil {
-    fn iclone(&self, _: usize) -> Self {
+    fn iclone(&self, _: u32) -> Self {
         match *self {}
     }
 }
@@ -295,11 +295,11 @@ impl<H: PartialEq, T: Comparer> PartialEq for Coproduct<UntaggedCoproduct<H, T>>
 }
 
 trait Comparer {
-    unsafe fn compare(i: usize, a: &Self, b: &Self) -> bool;
+    unsafe fn compare(i: u32, a: &Self, b: &Self) -> bool;
 }
 
 impl<H: PartialEq, T: Comparer> Comparer for UntaggedCoproduct<H, T> {
-    unsafe fn compare(i: usize, a: &Self, b: &Self) -> bool {
+    unsafe fn compare(i: u32, a: &Self, b: &Self) -> bool {
         if i == 0 {
             a.head == b.head
         } else {
@@ -309,7 +309,7 @@ impl<H: PartialEq, T: Comparer> Comparer for UntaggedCoproduct<H, T> {
 }
 
 impl Comparer for CNil {
-    unsafe fn compare(_: usize, a: &Self, _: &Self) -> bool {
+    unsafe fn compare(_: u32, a: &Self, _: &Self) -> bool {
         match *a {}
     }
 }
@@ -324,11 +324,11 @@ impl<H, T> std::fmt::Debug for Coproduct<UntaggedCoproduct<H, T>> {
 }
 
 pub trait Counter {
-    fn count() -> usize;
+    fn count() -> u32;
 }
 
 impl Counter for Here {
-    fn count() -> usize {
+    fn count() -> u32 {
         0
     }
 }
@@ -337,7 +337,7 @@ impl<N> Counter for There<N>
 where
     N: Counter,
 {
-    fn count() -> usize {
+    fn count() -> u32 {
         N::count() + 1
     }
 }

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -121,11 +121,16 @@ macro_rules! HList {
 /// ```
 #[macro_export]
 macro_rules! Coprod {
+    ($($tok:tt)*) => {$crate::coproduct::Coproduct<$crate::UntaggedCoprod!($($tok)*)>};
+}
+
+#[macro_export]
+macro_rules! UntaggedCoprod {
     () => { $crate::coproduct::CNil };
-    (...$Rest:ty) => { $Rest };
-    ($A:ty) => { $crate::Coprod![$A,] };
+    (...$Rest:ty) => { <$Rest as $crate::coproduct::Untagger>::Untagged };
+    ($A:ty) => { $crate::UntaggedCoprod![$A,] };
     ($A:ty, $($tok:tt)*) => {
-        $crate::coproduct::Coproduct<$A, $crate::Coprod![$($tok)*]>
+        $crate::coproduct::UntaggedCoproduct<$A, $crate::UntaggedCoprod![$($tok)*]>
     };
 }
 

--- a/derives/src/derive_labelled_generic.rs
+++ b/derives/src/derive_labelled_generic.rs
@@ -88,8 +88,7 @@ pub fn impl_labelled_generic(input: TokenStream) -> impl ToTokens {
             let coprod_exprs =
                 &variant_bindings.build_coprod_constrs(VariantBinding::build_hlist_field_expr);
             let coprod_pats =
-                &variant_bindings.build_coprod_constrs(VariantBinding::build_hlist_field_pat);
-            let coprod_unreachable = &variant_bindings.build_coprod_unreachable_arm(false);
+                &variant_bindings.build_coprod_pats(VariantBinding::build_hlist_field_pat);
             let type_constrs1 =
                 &variant_bindings.build_variant_constrs(VariantBinding::build_type_constr);
             let type_constrs2 = type_constrs1;
@@ -119,12 +118,11 @@ pub fn impl_labelled_generic(input: TokenStream) -> impl ToTokens {
 
                     #[inline(always)]
                     fn from(r: Self::Repr) -> Self {
-                        match r {
+                        r.fold(hlist![
                             #(
-                                #coprod_pats => #name_it2 :: #type_constrs2,
+                                |#coprod_pats| #name_it2 :: #type_constrs2,
                             )*
-                            #coprod_unreachable
-                        }
+                        ])
                     }
                 }
             };

--- a/tests/labelled_tests.rs
+++ b/tests/labelled_tests.rs
@@ -252,7 +252,7 @@ fn test_sculpt_enum() {
     };
     let repr = match into_labelled_generic(value).subset() {
         Ok(repr) => repr,
-        Err(rem) => match rem {}, // should be unreachable
+        Err(rem) => match frunk::coproduct::absurd(rem) {}, // should be unreachable
     };
     let new_value: LabelledEnum2 = from_labelled_generic(repr);
 


### PR DESCRIPTION
Instead of nesting enums, the new representation explicitly has one tag and nested unions. The nested unions only take up as much space as the largest variant of the coproduct, unlike the old representation, which was optimized very poorly by the compiler.

For example the below line takes 120 bytes on frunk 0.4 but only 16 bytes with my implementation. If I change the tag from `usize` to `u32` it drops to 8 bytes. This raises the question whether it is possible to dynamically choose a good tag size. It is probably not worth the complexity, though, as I suspect that tags larger than `u16` aren't practical simply because the data structure's size would slow down compilation too much.

```Rust
Coprod! {u8, u8, u8, u8, u32, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u32, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u32, u8, u8, u8, u8, u8, u8, u8};
```

The code passes all tests but it is still quite messy and some of the old Coproduct's API like Ord and Eq is still missing.

I also need to name the current Coproduct LeakingCoproduct and put it in yet another wrapper that has a custom Drop implementation. That, or make Coproduct only take values that are Copy.