### PR TITLE
turn links into hyperlinks

### DIFF
--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -716,7 +716,7 @@ where
 /// ```
 ///
 /// Credit:
-/// 1. Haskell "transmogrify" Github repo: https://github.com/ivan-m/transmogrify
+/// 1. Haskell "transmogrify" Github repo: <https://github.com/ivan-m/transmogrify>
 pub trait Transmogrifier<Target, TransmogrifyIndexIndices> {
     /// Consume this current object and return an object of the Target type.
     ///

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -42,7 +42,7 @@ macro_rules! hlist {
 
 /// Macro for pattern-matching on HLists.
 ///
-/// Taken from https://github.com/tbu-/rust-rfcs/blob/master/text/0873-type-macros.md
+/// Taken from <https://github.com/tbu-/rust-rfcs/blob/master/text/0873-type-macros.md>
 ///
 /// # Examples
 ///

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -5,7 +5,7 @@
 /// This lets us create implementations for our recursive traits that take the resulting
 /// Output reference type, without having to deal with strange, spurious overflows
 /// that sometimes occur when trying to implement a trait for &'a T (see this comment:
-/// https://github.com/lloydmeta/frunk/pull/106#issuecomment-377927198)
+/// <https://github.com/lloydmeta/frunk/pull/106#issuecomment-377927198>)
 ///
 /// This functionality is also provided as an inherent method [on HLists] and [on Coproducts].
 /// However, you may find this trait useful in generic contexts.


### PR DESCRIPTION
CI can catch this in the future with the following command:

```
RUSTDOCFLAGS="-D warnings" cargo doc \
    --workspace \
    --no-deps \
    --document-private-items
```

I would add it to CI in this PR, but I don't really know GitHub Actions all that well.