### PR TITLE
Typenum list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frunk"
 edition = "2021"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk provides developers with a number of functional programming tools like HList, Coproduct, Generic, LabelledGeneric, Validated, Monoid, Semigroup and friends."
 license = "MIT"
@@ -19,7 +19,7 @@ time = "0.3"
 [dependencies.frunk_core]
 path = "core"
 default-features = false
-version = "0.4.2"
+version = "0.5.0"
 
 [dependencies.frunk_proc_macros]
 path = "proc-macros"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ std = []
 
 [dependencies]
 serde = { version = "^1.0", optional = true, features = [ "derive" ] }
+typenum = { version = "1.17.0", default-features = false }
 
 [dev-dependencies.frunk_derives]
 path = "../derives"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frunk_core"
 edition = "2021"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk core provides developers with HList, Coproduct, LabelledGeneric and Generic"
 license = "MIT"
@@ -28,7 +28,7 @@ version = "0.4.1"
 [dev-dependencies.frunk]
 path = ".."
 default-features = false
-version = "0.4.2"
+version = "0.5.0"
 
 [dev-dependencies.frunk_proc_macros]
 path = "../proc-macros"

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -102,7 +102,7 @@ pub trait HList: Sized {
     /// assert_eq!(h.len(), 2);
     /// # }
     /// ```
-    #[deprecated(since = "0.5.0", note = "Please use Len::USIZE instead")]
+    #[deprecated(since = "0.5.0", note = "Please use <Self as HList>::Len::[USIZE | U8 | U32 | ... ] instead")]
     #[inline]
     fn len(&self) -> usize {
         <Self::Len as Unsigned>::USIZE
@@ -266,6 +266,9 @@ macro_rules! gen_inherent_methods {
             pub fn len(&self) -> usize
             where Self: HList,
             {
+                // this is how it's done at the type-level
+                // <Self as HList>::Len::USIZE
+                #[allow(deprecated)]
                 HList::len(self)
             }
 
@@ -286,6 +289,8 @@ macro_rules! gen_inherent_methods {
             where Self: HList,
             {
                 HList::is_empty(self)
+                // this is how it's done at the type-level
+                // <<<Self as HList>::Len as typenum::IsEqual<typenum::U0>>::Output as typenum::Bit>::BOOL
             }
 
             /// Prepend an item to the current HList

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -74,15 +74,18 @@ pub trait HList: Sized {
     /// # Examples
     /// ```
     /// # fn main() {
+    /// use typenum::Unsigned;
     /// use frunk::prelude::*;
     /// use frunk_core::HList;
     ///
-    /// fn foo<T: typenum::IsEqual<U3>>() {}
-    /// let _ = foo::<HList![(), i32, bool]::Len>();
-    /// let byte: u32 = HList![bool, &str, String]::Len::UINT32;
+    /// type LenThree = HList![bool, (), u8];
+    /// fn foo<T: typenum::IsEqual<typenum::U3>>() {}
+    ///
+    /// let _ = foo::<<LenThree as HList>::Len>();
+    /// let byte: u8 = <<LenThree as HList>::Len>::U8;
     ///
     ///
-    /// assert_eq!(<HList![i32, bool, f32]>::Len, 3);
+    /// assert_eq!(<LenThree as HList>::Len::USIZE, 3);
     /// # }
     /// ```
     type Len: Unsigned;

--- a/laws/Cargo.toml
+++ b/laws/Cargo.toml
@@ -15,7 +15,7 @@ travis-ci = { repository = "lloydmeta/frunk" }
 [dependencies.frunk]
 path = ".."
 default-features = false
-version = "0.4.2"
+version = "0.5.0"
 
 [dependencies]
 quickcheck = "1.0.3"

--- a/proc-macro-helpers/Cargo.toml
+++ b/proc-macro-helpers/Cargo.toml
@@ -20,4 +20,4 @@ proc-macro2 = "1"
 [dependencies.frunk_core]
 path = "../core"
 default-features = false
-version = "0.4.2"
+version = "0.5.0"

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -23,7 +23,7 @@ proc-macro = true
 [dependencies.frunk_core]
 path = "../core"
 default-features = false
-version = "0.4.2"
+version = "0.5.0"
 
 [dependencies.frunk_proc_macro_helpers]
 path = "../proc-macro-helpers"


### PR DESCRIPTION
This creates a version bump and upgrades the HList assossciated assosciated const LEN to an assostiated `type: typenum::Unsigned`

Motivation is as follows: I have a trait that needs a fixed length heterogenous list, but the length is generic to only a few numbers. the non generic way of implementing it:

```rust
pub trait HWApi1 {
    fn config<S: SetDutyCycle>(freq: embedded_time::rate::Hertz<u32>, pinA: S);
}
pub trait HWApi2 {
    fn config<S: SetDutyCycle, S: SetDutyCycle>(
        freq: embedded_time::rate::Hertz<u32>,
        pinA: S,
        pinB: S,
    );
}
pub trait HWApi3 {
    fn config<S: SetDutyCycle, S: SetDutyCycle, S: SetDutyCycle>(
        freq: embedded_time::rate::Hertz<u32>,
        pinA: S,
        pinB: S,
        pinC: S,
    );
}
```

I the requirements for this library are for `HWApi[1, 2, 3, 4, 6]` and I'd like to be able to define it as so:

```rust
pub trait HWApi<N>
where
    // constrain the values here
{
    fn config<L>(freq: ..., L) 
    where
        L: Hlist,
        <L as HList>::Len: IsEqual<N>,
        // make sure every item in the list is constrained to implementing `SetDutyCycle` here
    {
```

...This is only possible at the type level when HList has a canonical expression of its length at the type level as well.

