### PR TITLE
rework #![no_std] support, switch on `alloc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frunk"
 edition = "2021"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk provides developers with a number of functional programming tools like HList, Coproduct, Generic, LabelledGeneric, Validated, Monoid, Semigroup and friends."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,15 @@ version = "0.5.0"
 serde = { version = "^1.0", optional = true, features = [ "derive" ] }
 
 [features]
-default = ["validated", "proc-macros"]
-validated = ["std"]
+default = ["validated", "proc-macros", "alloc"]
+validated = ["alloc"]
 proc-macros = ["frunk_proc_macros"]
-std = ["frunk_core/std"]
+std = ["alloc", "serde?/std"]
+alloc = ["frunk_core/alloc", "serde?/alloc"]
+
+[[example]]
+name = "paths"
+required-features = ["proc-macros"]
 
 [profile.bench]
 opt-level = 3

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["Frunk", "HList", "Generic", "Coproduct", "LabelledGeneric"]
 travis-ci = { repository = "lloydmeta/frunk" }
 
 [features]
-default = ["std"]
-std = []
+default = ["alloc"]
+alloc = ["serde?/alloc"]
 
 [dependencies]
 serde = { version = "^1.0", optional = true, features = [ "derive" ] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frunk_core"
 edition = "2021"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "Frunk core provides developers with HList, Coproduct, LabelledGeneric and Generic"
 license = "MIT"
@@ -15,6 +15,9 @@ travis-ci = { repository = "lloydmeta/frunk" }
 [features]
 default = ["alloc"]
 alloc = ["serde?/alloc"]
+
+# deprecated -- to be removed in next major version
+std = ["alloc"]
 
 [dependencies]
 serde = { version = "^1.0", optional = true, features = [ "derive" ] }

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -1247,6 +1247,9 @@ mod tests {
     use super::Coproduct::*;
     use super::*;
 
+    use std::string::{String, ToString};
+    use std::format;
+
     #[test]
     fn test_coproduct_inject() {
         type I32StrBool = Coprod!(i32, &'static str, bool);
@@ -1267,7 +1270,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn test_coproduct_fold_consuming() {
         type I32F32StrBool = Coprod!(i32, f32, bool);
 
@@ -1312,7 +1314,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn test_coproduct_fold_non_consuming() {
         type I32F32Bool = Coprod!(i32, f32, bool);
 

--- a/core/src/coproduct.rs
+++ b/core/src/coproduct.rs
@@ -1247,8 +1247,8 @@ mod tests {
     use super::Coproduct::*;
     use super::*;
 
-    use std::string::{String, ToString};
     use std::format;
+    use std::string::{String, ToString};
 
     #[test]
     fn test_coproduct_inject() {

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -59,8 +59,10 @@ use crate::indices::{Here, Suffixed, There};
 use crate::traits::{Func, IntoReverse, Poly, ToMut, ToRef};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
-use std::ops::Add;
+use core::ops::Add;
 
 /// Typeclass for HList-y behaviour
 ///
@@ -432,7 +434,7 @@ macro_rules! gen_inherent_methods {
             /// # }
             /// ```
             #[inline(always)]
-            pub fn map<F>(self,mapper: F) -> <Self as HMappable<F>>::Output
+            pub fn map<F>(self, mapper: F) -> <Self as HMappable<F>>::Output
             where Self: HMappable<F>,
             {
                 HMappable::map(self, mapper)
@@ -1433,7 +1435,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 #[allow(clippy::from_over_into)]
 impl<H, Tail> Into<Vec<H>> for HCons<H, Tail>
 where
@@ -1450,7 +1452,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 #[allow(clippy::from_over_into)]
 impl<T> Into<Vec<T>> for HNil {
     fn into(self) -> Vec<T> {
@@ -1576,6 +1578,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use alloc::vec;
 
     #[test]
     fn test_hcons() {
@@ -1909,7 +1913,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn test_single_func_foldl_consuming() {
         use std::collections::HashMap;
 
@@ -1949,7 +1952,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn test_into_vec() {
         let h = hlist![1, 2, 3, 4, 5];
         let as_vec: Vec<_> = h.into();

--- a/core/src/hlist.rs
+++ b/core/src/hlist.rs
@@ -57,10 +57,10 @@
 
 use crate::indices::{Here, Suffixed, There};
 use crate::traits::{Func, IntoReverse, Poly, ToMut, ToRef};
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Add;
 

--- a/core/src/indices.rs
+++ b/core/src/indices.rs
@@ -11,7 +11,7 @@
 //!
 //! **...yet.** `;)`
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 // Largely lifted from https://github.com/Sgeo/hlist/blob/master/src/lib.rs#L30
 

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -737,9 +737,9 @@ impl<Key, SourceValue> Transmogrifier<SourceValue, IdentityTransMog> for Field<K
 mod _alloc {
     use super::MappingIndicesWrapper;
     use super::{Field, Transmogrifier};
+    use alloc::boxed::Box;
     use alloc::collections::{LinkedList, VecDeque};
     use alloc::vec::Vec;
-    use alloc::boxed::Box;
 
     macro_rules! transmogrify_seq {
         ($container:ident) => {
@@ -917,8 +917,7 @@ mod tests {
     use super::chars::*;
     use super::*;
     use alloc::collections::{LinkedList, VecDeque};
-    use alloc::{boxed::Box, vec::Vec, format, vec};
-
+    use alloc::{boxed::Box, format, vec, vec::Vec};
 
     // Set up some aliases
     #[allow(non_camel_case_types)]

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -152,8 +152,8 @@ use crate::indices::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use ::std::fmt;
-use ::std::marker::PhantomData;
+use core::fmt;
+use core::marker::PhantomData;
 
 /// A trait that converts from a type to a labelled generic representation.
 ///
@@ -733,11 +733,13 @@ impl<Key, SourceValue> Transmogrifier<SourceValue, IdentityTransMog> for Field<K
 }
 
 /// Implementations of `Transmogrifier` that allow recursion through stdlib container types.
-#[cfg(feature = "std")]
-mod std {
+#[cfg(feature = "alloc")]
+mod _alloc {
     use super::MappingIndicesWrapper;
     use super::{Field, Transmogrifier};
-    use std::collections::{LinkedList, VecDeque};
+    use alloc::collections::{LinkedList, VecDeque};
+    use alloc::vec::Vec;
+    use alloc::boxed::Box;
 
     macro_rules! transmogrify_seq {
         ($container:ident) => {
@@ -914,7 +916,9 @@ where
 mod tests {
     use super::chars::*;
     use super::*;
-    use ::std::collections::{LinkedList, VecDeque};
+    use alloc::collections::{LinkedList, VecDeque};
+    use alloc::{boxed::Box, vec::Vec, format, vec};
+
 
     // Set up some aliases
     #[allow(non_camel_case_types)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,5 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+
 #![doc(html_playground_url = "https://play.rust-lang.org/")]
 //! Frunk Core
 //!
@@ -58,8 +59,11 @@
 //!   1. [Source on Github](https://github.com/lloydmeta/frunk)
 //!   2. [Crates.io page](https://crates.io/crates/frunk)
 
-#[cfg(not(feature = "std"))]
-extern crate core as std;
+#[cfg(test)]
+extern crate std;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 #[macro_use]
 mod macros;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-
 #![doc(html_playground_url = "https://play.rust-lang.org/")]
 //! Frunk Core
 //!

--- a/core/src/path.rs
+++ b/core/src/path.rs
@@ -108,8 +108,8 @@
 use super::hlist::*;
 use super::labelled::*;
 
-use std::marker::PhantomData;
-use std::ops::Add;
+use core::marker::PhantomData;
+use core::ops::Add;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Path<T>(PhantomData<T>);

--- a/laws/Cargo.toml
+++ b/laws/Cargo.toml
@@ -16,6 +16,7 @@ travis-ci = { repository = "lloydmeta/frunk" }
 path = ".."
 default-features = false
 version = "0.4.2"
+features = ["std"]
 
 [dependencies]
 quickcheck = "1.0.3"

--- a/laws/Cargo.toml
+++ b/laws/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frunk_laws"
 edition = "2021"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Lloyd <lloydmeta@gmail.com>"]
 description = "frunk_laws contains laws for algebras declared in Frunk."
 license = "MIT"

--- a/laws/src/monoid_laws.rs
+++ b/laws/src/monoid_laws.rs
@@ -66,39 +66,33 @@ mod tests {
     use crate::wrapper::*;
     use frunk::semigroup::*;
     use quickcheck::quickcheck;
-    #[cfg(feature = "std")]
     use std::collections::{HashMap, HashSet};
 
     #[test]
-    #[cfg(feature = "std")]
     fn string_id_prop() {
         quickcheck(left_identity as fn(String) -> bool);
         quickcheck(right_identity as fn(String) -> bool);
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn option_id_prop() {
         quickcheck(left_identity as fn(Option<String>) -> bool);
         quickcheck(right_identity as fn(Option<String>) -> bool);
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn vec_id_prop() {
         quickcheck(left_identity as fn(Vec<String>) -> bool);
         quickcheck(right_identity as fn(Vec<String>) -> bool);
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn hashset_id_prop() {
         quickcheck(left_identity as fn(HashSet<i32>) -> bool);
         quickcheck(right_identity as fn(HashSet<i32>) -> bool);
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn hashmap_id_prop() {
         quickcheck(left_identity as fn(HashMap<i32, String>) -> bool);
         quickcheck(right_identity as fn(HashMap<i32, String>) -> bool);

--- a/laws/src/semigroup_laws.rs
+++ b/laws/src/semigroup_laws.rs
@@ -42,35 +42,29 @@ mod tests {
     use super::*;
     use crate::wrapper::*;
     use quickcheck::quickcheck;
-    #[cfg(feature = "std")]
     use std::collections::{HashMap, HashSet};
 
     #[test]
-    #[cfg(feature = "std")]
     fn string_prop() {
         quickcheck(associativity as fn(String, String, String) -> bool)
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn option_prop() {
         quickcheck(associativity as fn(Option<String>, Option<String>, Option<String>) -> bool)
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn vec_prop() {
         quickcheck(associativity as fn(Vec<i8>, Vec<i8>, Vec<i8>) -> bool)
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn hashset_prop() {
         quickcheck(associativity as fn(HashSet<i8>, HashSet<i8>, HashSet<i8>) -> bool)
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn hashmap_prop() {
         quickcheck(
             associativity

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-
 #![doc(html_playground_url = "https://play.rust-lang.org/")]
 //! Frunk: generic functional programming toolbelt for Rust
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+
 #![doc(html_playground_url = "https://play.rust-lang.org/")]
 //! Frunk: generic functional programming toolbelt for Rust
 //!
@@ -13,7 +14,7 @@
 //!   6. Monoid
 //!
 #![cfg_attr(
-    feature = "std",
+    feature = "alloc",
     doc = r#"
 Here is a small taste of what Frunk has to offer:
 
@@ -201,8 +202,11 @@ assert_eq!(d_user.first_name, "Joe");
 //!   1. [Source on Github](https://github.com/lloydmeta/frunk)
 //!   2. [Crates.io page](https://crates.io/crates/frunk)
 
-#[cfg(not(feature = "std"))]
-extern crate core as std;
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(any(feature = "std", test))]
+extern crate std;
 
 pub mod monoid;
 pub mod semigroup;

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -299,7 +299,7 @@ mod tests {
     use super::*;
 
     #[cfg(feature = "alloc")]
-    use alloc::{vec, borrow::ToOwned};
+    use alloc::{borrow::ToOwned, vec};
 
     #[test]
     fn test_combine_n() {

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -11,7 +11,8 @@ their values are summed in the new map?
 # Examples
 
 ```
-use std::collections::HashMap;
+# extern crate std;
+# use std::collections::HashMap;
 use frunk::{monoid, Monoid};
 
 let vec_of_no_hashmaps: Vec<HashMap<i32, String>> = Vec::new();
@@ -37,10 +38,12 @@ assert_eq!(monoid::combine_all(&vec_of_hashes), h_expected);
 )]
 
 use super::semigroup::{All, Any, Product, Semigroup};
+#[cfg(feature = "alloc")]
+use alloc::{string::String, vec::Vec};
+#[cfg(feature = "std")]
+use core::hash::Hash;
 #[cfg(feature = "std")]
 use std::collections::*;
-#[cfg(feature = "std")]
-use std::hash::Hash;
 
 /// A Monoid is a Semigroup that has an empty/ zero value
 pub trait Monoid: Semigroup {
@@ -78,11 +81,14 @@ where
 
 /// Given a sequence of `xs`, combine them and return the total
 #[cfg_attr(
-    feature = "std",
+    feature = "alloc",
     doc = r#"
 # Examples
 
 ```
+# extern crate alloc;
+# use alloc::vec::Vec;
+# use alloc::string::String;
 use frunk::monoid::combine_all;
 
 assert_eq!(combine_all(&vec![Some(1), Some(3)]), Some(4));
@@ -111,14 +117,14 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl Monoid for String {
     fn empty() -> Self {
         String::new()
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<T> Monoid for Vec<T>
 where
     T: Clone,
@@ -292,6 +298,9 @@ mod tests {
     use super::super::semigroup::{All, Any, Product};
     use super::*;
 
+    #[cfg(feature = "alloc")]
+    use alloc::{vec, borrow::ToOwned};
+
     #[test]
     fn test_combine_n() {
         assert_eq!(combine_n(&1, 0), 0);
@@ -301,7 +310,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn test_combine_all_basic() {
         assert_eq!(combine_all(&[1, 2, 3]), 6);
         assert_eq!(combine_all(&[] as &[i32]), 0);
@@ -383,7 +392,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn test_combine_all_tuple() {
         let t1 = (1, 2.5f32, String::from("hi"), Some(3));
         let t2 = (1, 2.5f32, String::from(" world"), None);

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -1,7 +1,9 @@
 //! Module for holding the Semigroup typeclass definition and typeclass instances
 //!
 //! You can, for example, combine tuples.
-#![cfg_attr(feature = "alloc", doc = r#"
+#![cfg_attr(
+    feature = "alloc",
+    doc = r#"
 # Examples
 
 ```
@@ -27,18 +29,18 @@ assert_eq!(h1.combine(&h2), h3)
 ```"#
 )]
 
-use frunk_core::hlist::*;
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::cell::*;
 use core::cmp::Ordering;
+#[cfg(feature = "alloc")]
+use core::hash::Hash;
+use core::ops::{BitAnd, BitOr, Deref};
+use frunk_core::hlist::*;
 #[cfg(feature = "std")]
 use std::collections::hash_map::Entry;
 #[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
-#[cfg(feature = "alloc")]
-use core::hash::Hash;
-#[cfg(feature = "alloc")]
-use alloc::{string::String, vec::Vec, boxed::Box};
-use core::ops::{BitAnd, BitOr, Deref};
 
 /// Wrapper type for types that are ordered and can have a Max combination
 #[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
@@ -362,9 +364,9 @@ tuple_impls! {
 mod tests {
     use super::*;
     #[cfg(feature = "alloc")]
-    use frunk_core::hlist;
-    #[cfg(feature = "alloc")]
     use alloc::{borrow::ToOwned, vec};
+    #[cfg(feature = "alloc")]
+    use frunk_core::hlist;
 
     macro_rules! semigroup_tests {
       ($($name:ident, $comb: expr => $expected: expr, $tr:ty)+) => {

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -1,9 +1,7 @@
 //! Module for holding the Semigroup typeclass definition and typeclass instances
 //!
 //! You can, for example, combine tuples.
-#![cfg_attr(
-    feature = "std",
-    doc = r#"
+#![cfg_attr(feature = "alloc", doc = r#"
 # Examples
 
 ```
@@ -30,15 +28,17 @@ assert_eq!(h1.combine(&h2), h3)
 )]
 
 use frunk_core::hlist::*;
-use std::cell::*;
-use std::cmp::Ordering;
+use core::cell::*;
+use core::cmp::Ordering;
 #[cfg(feature = "std")]
 use std::collections::hash_map::Entry;
 #[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
-#[cfg(feature = "std")]
-use std::hash::Hash;
-use std::ops::{BitAnd, BitOr, Deref};
+#[cfg(feature = "alloc")]
+use core::hash::Hash;
+#[cfg(feature = "alloc")]
+use alloc::{string::String, vec::Vec, boxed::Box};
+use core::ops::{BitAnd, BitOr, Deref};
 
 /// Wrapper type for types that are ordered and can have a Max combination
 #[derive(PartialEq, Debug, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
@@ -168,14 +168,14 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<T: Semigroup> Semigroup for Box<T> {
     fn combine(&self, other: &Self) -> Self {
         Box::new(self.deref().combine(other.deref()))
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl Semigroup for String {
     fn combine(&self, other: &Self) -> Self {
         let mut cloned = self.clone();
@@ -184,7 +184,7 @@ impl Semigroup for String {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<T: Clone> Semigroup for Vec<T> {
     fn combine(&self, other: &Self) -> Self {
         let mut v = self.clone();
@@ -361,7 +361,10 @@ tuple_impls! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "alloc")]
     use frunk_core::hlist;
+    #[cfg(feature = "alloc")]
+    use alloc::{borrow::ToOwned, vec};
 
     macro_rules! semigroup_tests {
       ($($name:ident, $comb: expr => $expected: expr, $tr:ty)+) => {
@@ -393,7 +396,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn test_string() {
         let v1 = String::from("Hello");
         let v2 = String::from(" world");
@@ -401,7 +404,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn test_vec_i32() {
         let v1 = vec![1, 2, 3];
         let v2 = vec![4, 5, 6];
@@ -506,7 +509,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn test_combine_hlist() {
         let h1 = hlist![Some(1), 3.3, 53i64, "hello".to_owned()];
         let h2 = hlist![Some(2), 1.2, 1i64, " world".to_owned()];

--- a/src/validated.rs
+++ b/src/validated.rs
@@ -46,8 +46,8 @@
 
 use super::hlist::*;
 
-use core::ops::Add;
 use alloc::{vec, vec::Vec};
+use core::ops::Add;
 
 /// A Validated is either an Ok holding an HList or an Err, holding a vector
 /// of collected errors.
@@ -245,8 +245,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use frunk_core::{hlist, hlist_pat};
     use alloc::{borrow::ToOwned, string::String};
+    use frunk_core::{hlist, hlist_pat};
 
     #[test]
     fn test_adding_ok_results() {

--- a/src/validated.rs
+++ b/src/validated.rs
@@ -46,7 +46,8 @@
 
 use super::hlist::*;
 
-use std::ops::Add;
+use core::ops::Add;
+use alloc::{vec, vec::Vec};
 
 /// A Validated is either an Ok holding an HList or an Err, holding a vector
 /// of collected errors.
@@ -245,6 +246,7 @@ where
 mod tests {
     use super::*;
     use frunk_core::{hlist, hlist_pat};
+    use alloc::{borrow::ToOwned, string::String};
 
     #[test]
     fn test_adding_ok_results() {


### PR DESCRIPTION
Finally got around to change I brought up in #220. See also #233.

Most of the uses of `std` in the crate are of `Vec`, `String`, and `Box`, which are in `alloc`, which is available on `#![no_std]` via `extern crate alloc;`. This commit adjusts these uses to use `alloc` directly and adds an `alloc` feature flag to control them. The notable exceptions still requiring a `std` flag are `HashMap` and `HashSet` (I'm working on a separate change to add `BTree{Map,Set}` support for `#![no_std]` envs). `frunk_core` no longer needs a `std` flag: it has been marked deprecated with a comment.

The reimport of `core` as `std` (see #220 for historical explanation) is converted to direct usage of `core` everywhere.

Removed `#[cfg(feature = "std")]` condition from `frunk_laws` and made it depend on `frunk/std` -- it depends on `quickcheck`, which requires `std`.

Added `#[cfg(test)] extern crate std;` to `#![no_std]` crates, as `std` is required to run the libtest harness.

Tested against all the combinations of feature flags I could think of. Successfully compiles into a `#![no_std]` embedded project with `alloc` enabled.