### PR TITLE
Add a test to check that LabelledGeneric works with keyword fields

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -53,6 +53,26 @@ pub struct SuperLongField {
     pub abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789: i32,
 }
 
+#[derive(LabelledGeneric)]
+pub struct HasKeyword1 {
+    pub r#type: i32,
+}
+
+#[derive(LabelledGeneric)]
+pub struct HasKeyword2 {
+    pub r#type: i32,
+}
+
+#[derive(LabelledGeneric)]
+pub struct HasKeyword1Embedder {
+    pub r#true: HasKeyword1,
+}
+
+#[derive(LabelledGeneric)]
+pub struct HasKeyword2Embedder {
+    pub r#true: HasKeyword2,
+}
+
 #[derive(Generic, Debug, PartialEq, Eq)]
 pub struct TupleStruct<'a>(pub &'a str, pub i32);
 

--- a/tests/labelled_tests.rs
+++ b/tests/labelled_tests.rs
@@ -260,3 +260,20 @@ fn test_sculpt_enum() {
         }
     );
 }
+
+#[test]
+fn test_transmogrify_keyword_field_structs() {
+    let value = HasKeyword1 { r#type: 3 };
+    let result: HasKeyword2 = value.transmogrify();
+    assert_eq!(3, result.r#type);
+}
+
+#[test]
+fn test_transmogrify_keyword_field_embedder_structs() {
+    let value = {
+        let embedded = HasKeyword1 { r#type: 3 };
+        HasKeyword1Embedder { r#true: embedded }
+    };
+    let result: HasKeyword2Embedder = value.transmogrify();
+    assert_eq!(3, result.r#true.r#type);
+}


### PR DESCRIPTION
Checks that derives works and transmogrifying works.

Related: 
* https://github.com/OpenAPITools/openapi-generator/issues/13867
* Possibly fixed through https://github.com/lloydmeta/frunk/pull/214