### PR TITLE
Add Generic support for enum representations

### DIFF
--- a/core/src/generic.rs
+++ b/core/src/generic.rs
@@ -31,6 +31,9 @@
 //! let d_person: DomainPerson = frunk::convert_from(a_person); // done
 //! # }
 
+use crate::coproduct::Coproduct;
+use crate::hlist::HNil;
+
 /// A trait that converts from a type to a generic representation.
 ///
 /// For the most part, you should be using the derivation that is available
@@ -117,6 +120,74 @@ pub trait Generic {
         Mapper: FnOnce(Inter) -> Inter,
     {
         Self::convert_from(mapper(Inter::convert_from(self)))
+    }
+}
+
+type UnaryVariant<T> = crate::HList!(T);
+type GenericOptionRepr<T> = crate::Coprod!(HNil, UnaryVariant<T>);
+type GenericResultRepr<T, E> = crate::Coprod!(UnaryVariant<T>, UnaryVariant<E>);
+type GenericBoolRepr = crate::Coprod!(HNil, HNil);
+
+impl<T> Generic for Option<T> {
+    type Repr = GenericOptionRepr<T>;
+
+    #[inline(always)]
+    fn into(self) -> Self::Repr {
+        match self {
+            None => Coproduct::Inl(crate::hlist![]),
+            Some(value) => Coproduct::Inr(Coproduct::Inl(crate::hlist![value])),
+        }
+    }
+
+    #[inline(always)]
+    fn from(repr: Self::Repr) -> Self {
+        match repr {
+            Coproduct::Inl(crate::hlist_pat![]) => None,
+            Coproduct::Inr(Coproduct::Inl(crate::hlist_pat![value])) => Some(value),
+            Coproduct::Inr(Coproduct::Inr(cnil)) => match cnil {},
+        }
+    }
+}
+
+impl<T, E> Generic for Result<T, E> {
+    type Repr = GenericResultRepr<T, E>;
+
+    #[inline(always)]
+    fn into(self) -> Self::Repr {
+        match self {
+            Ok(value) => Coproduct::Inl(crate::hlist![value]),
+            Err(value) => Coproduct::Inr(Coproduct::Inl(crate::hlist![value])),
+        }
+    }
+
+    #[inline(always)]
+    fn from(repr: Self::Repr) -> Self {
+        match repr {
+            Coproduct::Inl(crate::hlist_pat![value]) => Ok(value),
+            Coproduct::Inr(Coproduct::Inl(crate::hlist_pat![value])) => Err(value),
+            Coproduct::Inr(Coproduct::Inr(cnil)) => match cnil {},
+        }
+    }
+}
+
+impl Generic for bool {
+    type Repr = GenericBoolRepr;
+
+    #[inline(always)]
+    fn into(self) -> Self::Repr {
+        match self {
+            false => Coproduct::Inl(crate::hlist![]),
+            true => Coproduct::Inr(Coproduct::Inl(crate::hlist![])),
+        }
+    }
+
+    #[inline(always)]
+    fn from(repr: Self::Repr) -> Self {
+        match repr {
+            Coproduct::Inl(crate::hlist_pat![]) => false,
+            Coproduct::Inr(Coproduct::Inl(crate::hlist_pat![])) => true,
+            Coproduct::Inr(Coproduct::Inr(cnil)) => match cnil {},
+        }
     }
 }
 

--- a/core/src/labelled.rs
+++ b/core/src/labelled.rs
@@ -147,9 +147,11 @@
 //! # }
 //! ```
 
+use crate::coproduct::Coproduct;
 use crate::hlist::*;
 use crate::indices::*;
 use crate::traits::ToRef;
+use chars::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -279,6 +281,125 @@ where
     #[inline(always)]
     fn into(self) -> <Self as IntoLabelledGeneric>::Repr {
         self.into()
+    }
+}
+
+type NoneLabel = (N, o, n, e);
+type SomeLabel = (S, o, m, e);
+type OkLabel = (O, k);
+type ErrLabel = (E, r, r);
+type FalseLabel = (f, a, l, s, e);
+type TrueLabel = (t, r, u, e);
+type TupleField0 = (__, _0);
+type UnitVariant<Name> = Field<Name, HNil>;
+type UnaryTupleVariant<Name, T> = Field<Name, crate::HList!(Field<TupleField0, T>)>;
+type LabelledOptionRepr<T> =
+    crate::Coprod!(UnitVariant<NoneLabel>, UnaryTupleVariant<SomeLabel, T>);
+type LabelledResultRepr<T, E> =
+    crate::Coprod!(UnaryTupleVariant<OkLabel, T>, UnaryTupleVariant<ErrLabel, E>);
+type LabelledBoolRepr = crate::Coprod!(UnitVariant<FalseLabel>, UnitVariant<TrueLabel>);
+
+#[inline(always)]
+fn labelled_tuple_field_0<T>(value: T) -> Field<TupleField0, T> {
+    crate::field!(TupleField0, value, "_0")
+}
+
+#[inline(always)]
+fn labelled_unit_variant<Name>(name: &'static str) -> UnitVariant<Name> {
+    crate::field!(Name, crate::hlist![], name)
+}
+
+#[inline(always)]
+fn labelled_unary_tuple_variant<Name, T>(
+    name: &'static str,
+    value: T,
+) -> UnaryTupleVariant<Name, T> {
+    crate::field!(Name, crate::hlist![labelled_tuple_field_0(value)], name)
+}
+
+impl<T> LabelledGeneric for Option<T> {
+    type Repr = LabelledOptionRepr<T>;
+
+    #[inline(always)]
+    fn into(self) -> Self::Repr {
+        match self {
+            None => Coproduct::Inl(labelled_unit_variant::<NoneLabel>("None")),
+            Some(value) => Coproduct::Inr(Coproduct::Inl(labelled_unary_tuple_variant::<
+                SomeLabel,
+                _,
+            >("Some", value))),
+        }
+    }
+
+    #[inline(always)]
+    fn from(repr: Self::Repr) -> Self {
+        match repr {
+            Coproduct::Inl(Field {
+                value: crate::hlist_pat![],
+                ..
+            }) => None,
+            Coproduct::Inr(Coproduct::Inl(Field {
+                value: crate::hlist_pat![Field { value, .. }],
+                ..
+            })) => Some(value),
+            Coproduct::Inr(Coproduct::Inr(cnil)) => match cnil {},
+        }
+    }
+}
+
+impl<T, E> LabelledGeneric for Result<T, E> {
+    type Repr = LabelledResultRepr<T, E>;
+
+    #[inline(always)]
+    fn into(self) -> Self::Repr {
+        match self {
+            Ok(value) => Coproduct::Inl(labelled_unary_tuple_variant::<OkLabel, _>("Ok", value)),
+            Err(value) => Coproduct::Inr(Coproduct::Inl(
+                labelled_unary_tuple_variant::<ErrLabel, _>("Err", value),
+            )),
+        }
+    }
+
+    #[inline(always)]
+    fn from(repr: Self::Repr) -> Self {
+        match repr {
+            Coproduct::Inl(Field {
+                value: crate::hlist_pat![Field { value, .. }],
+                ..
+            }) => Ok(value),
+            Coproduct::Inr(Coproduct::Inl(Field {
+                value: crate::hlist_pat![Field { value, .. }],
+                ..
+            })) => Err(value),
+            Coproduct::Inr(Coproduct::Inr(cnil)) => match cnil {},
+        }
+    }
+}
+
+impl LabelledGeneric for bool {
+    type Repr = LabelledBoolRepr;
+
+    #[inline(always)]
+    fn into(self) -> Self::Repr {
+        match self {
+            false => Coproduct::Inl(labelled_unit_variant::<FalseLabel>("false")),
+            true => Coproduct::Inr(Coproduct::Inl(labelled_unit_variant::<TrueLabel>("true"))),
+        }
+    }
+
+    #[inline(always)]
+    fn from(repr: Self::Repr) -> Self {
+        match repr {
+            Coproduct::Inl(Field {
+                value: crate::hlist_pat![],
+                ..
+            }) => false,
+            Coproduct::Inr(Coproduct::Inl(Field {
+                value: crate::hlist_pat![],
+                ..
+            })) => true,
+            Coproduct::Inr(Coproduct::Inr(cnil)) => match cnil {},
+        }
     }
 }
 
@@ -968,7 +1089,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::chars::*;
     use super::*;
     use alloc::collections::{LinkedList, VecDeque};
     use alloc::{boxed::Box, format, string::ToString, vec, vec::Vec};

--- a/derives/src/derive_generic.rs
+++ b/derives/src/derive_generic.rs
@@ -4,7 +4,8 @@ use quote::ToTokens;
 use std::iter::repeat;
 use syn::Data;
 
-/// Given an AST, returns an implementation of Generic using HList
+/// Given an AST, returns an implementation of Generic using an HList
+/// representation for structs and a Coproduct of payload HLists for enums.
 ///
 /// Works with structs, tuple structs, and enums.
 pub fn impl_generic(input: TokenStream) -> impl ToTokens {

--- a/derives/src/derive_generic.rs
+++ b/derives/src/derive_generic.rs
@@ -1,11 +1,12 @@
 use frunk_proc_macro_helpers::*;
 use proc_macro::TokenStream;
 use quote::ToTokens;
+use std::iter::repeat;
 use syn::Data;
 
 /// Given an AST, returns an implementation of Generic using HList
 ///
-/// Only works with Structs and Tuple Structs
+/// Works with structs, tuple structs, and enums.
 pub fn impl_generic(input: TokenStream) -> impl ToTokens {
     let ast = to_ast(input);
     let name = &ast.ident;
@@ -39,7 +40,44 @@ pub fn impl_generic(input: TokenStream) -> impl ToTokens {
                 }
             }
         }
-        _ => panic!("Only Structs are supported. Enums/Unions cannot be turned into Generics."),
+        Data::Enum(ref data) => {
+            let variant_bindings = VariantBindings::new(&data.variants);
+            let repr_type = &variant_bindings.build_coprod_type(VariantBinding::build_hlist_type);
+            let coprod_constrs =
+                &variant_bindings.build_coprod_constrs(VariantBinding::build_hlist_constr);
+            let coprod_unreachable = &variant_bindings.build_coprod_unreachable_arm(false);
+            let type_constrs1 =
+                &variant_bindings.build_variant_constrs(VariantBinding::build_type_constr);
+            let type_constrs2 = type_constrs1;
+            let name_it1 = repeat(name);
+            let name_it2 = repeat(name);
+
+            quote! {
+                #[allow(non_snake_case, non_camel_case_types)]
+                impl #impl_generics ::frunk_core::generic::Generic for #name #ty_generics #where_clause {
+
+                    type Repr = #repr_type;
+
+                    fn into(self) -> Self::Repr {
+                        match self {
+                            #(
+                                #name_it1 :: #type_constrs1 => #coprod_constrs,
+                            )*
+                        }
+                    }
+
+                    fn from(r: Self::Repr) -> Self {
+                        match r {
+                            #(
+                                #coprod_constrs => #name_it2 :: #type_constrs2,
+                            )*
+                            #coprod_unreachable
+                        }
+                    }
+                }
+            }
+        }
+        _ => panic!("Only Structs and Enums can be turned into Generics."),
     };
 
     //     print!("{}", tree);

--- a/derives/src/lib.rs
+++ b/derives/src/lib.rs
@@ -26,7 +26,7 @@ use crate::derive_labelled_generic::impl_labelled_generic;
 use quote::ToTokens;
 
 /// Derives a Generic instance based on HList for
-/// a given Struct or Tuple Struct
+/// a given struct, tuple struct, or enum.
 #[proc_macro_derive(Generic)]
 pub fn generic(input: TokenStream) -> TokenStream {
     // Build the impl

--- a/derives/src/lib.rs
+++ b/derives/src/lib.rs
@@ -25,8 +25,8 @@ use crate::derive_labelled_generic::impl_labelled_generic;
 
 use quote::ToTokens;
 
-/// Derives a Generic instance based on HList for
-/// a given struct, tuple struct, or enum.
+/// Derives a Generic instance based on HList for structs and
+/// Coproducts of payload HLists for enums.
 #[proc_macro_derive(Generic)]
 pub fn generic(input: TokenStream) -> TokenStream {
     // Build the impl

--- a/proc-macro-helpers/src/lib.rs
+++ b/proc-macro-helpers/src/lib.rs
@@ -397,6 +397,12 @@ impl VariantBinding {
                 .build_hlist_constr(FieldBinding::build_field_pat),
         )
     }
+    pub fn build_hlist_type(&self) -> TokenStream2 {
+        self.fields.build_hlist_type(FieldBinding::build_type)
+    }
+    pub fn build_hlist_constr(&self) -> TokenStream2 {
+        self.fields.build_hlist_constr(FieldBinding::build)
+    }
 }
 
 pub struct VariantBindings {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -80,6 +80,14 @@ pub struct HasKeyword2Embedder {
 #[derive(Generic, Debug, PartialEq, Eq)]
 pub struct TupleStruct<'a>(pub &'a str, pub i32);
 
+#[allow(dead_code)] // Not actually dead -- used in tests but clippy can't find it
+#[derive(Generic, PartialEq, Eq, Debug)]
+pub enum GenericEnum {
+    VariantA,
+    VariantB(i32),
+    VariantC { x: String, y: bool },
+}
+
 #[derive(LabelledGeneric)]
 pub struct NormalUser<'a> {
     pub first_name: &'a str,

--- a/tests/generic_tests.rs
+++ b/tests/generic_tests.rs
@@ -1,4 +1,4 @@
-use frunk::{convert_from, from_generic, into_generic};
+use frunk::{convert_from, from_generic, into_generic, Coproduct};
 use frunk_core::hlist;
 
 mod common;
@@ -26,6 +26,29 @@ fn test_tuple_struct_from_generic() {
 }
 
 #[test]
+fn test_enum_from_generic() {
+    let variant_a = Coproduct::inject(hlist![]);
+    let variant_b = Coproduct::inject(hlist![42i32]);
+    let variant_c = Coproduct::inject(hlist!["test".to_string(), true]);
+
+    assert_eq!(
+        from_generic::<GenericEnum, _>(variant_a),
+        GenericEnum::VariantA,
+    );
+    assert_eq!(
+        from_generic::<GenericEnum, _>(variant_b),
+        GenericEnum::VariantB(42),
+    );
+    assert_eq!(
+        from_generic::<GenericEnum, _>(variant_c),
+        GenericEnum::VariantC {
+            x: "test".into(),
+            y: true,
+        },
+    );
+}
+
+#[test]
 fn test_struct_into_generic() {
     let p = Person {
         first_name: "Humpty",
@@ -34,6 +57,23 @@ fn test_struct_into_generic() {
     };
     let h = into_generic(p);
     assert_eq!(h, hlist!("Humpty", "Drumpty", 3));
+}
+
+#[test]
+fn test_enum_into_generic() {
+    let variant_a = into_generic(GenericEnum::VariantA);
+    let variant_b = into_generic(GenericEnum::VariantB(42));
+    let variant_c = into_generic(GenericEnum::VariantC {
+        x: "test".into(),
+        y: true,
+    });
+
+    assert_eq!(variant_a, Coproduct::inject(hlist![]));
+    assert_eq!(variant_b, Coproduct::inject(hlist![42i32]));
+    assert_eq!(
+        variant_c,
+        Coproduct::inject(hlist!["test".to_string(), true])
+    );
 }
 
 #[test]

--- a/tests/generic_tests.rs
+++ b/tests/generic_tests.rs
@@ -1,4 +1,4 @@
-use frunk::{convert_from, from_generic, into_generic, Coproduct};
+use frunk::{convert_from, from_generic, into_generic, Coproduct, Generic};
 use frunk_core::hlist;
 
 mod common;
@@ -74,6 +74,43 @@ fn test_enum_into_generic() {
         variant_c,
         Coproduct::inject(hlist!["test".to_string(), true])
     );
+}
+
+#[test]
+fn test_option_generic() {
+    let none_repr = into_generic(None::<i32>);
+    let some_repr = into_generic(Some(42i32));
+
+    assert_eq!(none_repr, Coproduct::Inl(hlist![]));
+    assert_eq!(some_repr, Coproduct::Inr(Coproduct::Inl(hlist![42i32])));
+    assert_eq!(from_generic::<Option<i32>, _>(none_repr), None);
+    assert_eq!(from_generic::<Option<i32>, _>(some_repr), Some(42));
+}
+
+#[test]
+fn test_result_generic() {
+    let ok_repr = into_generic(Ok::<i32, &str>(42));
+    let err_repr = into_generic(Err::<i32, &str>("error"));
+
+    assert_eq!(ok_repr, Coproduct::Inl(hlist![42i32]));
+    assert_eq!(err_repr, Coproduct::Inr(Coproduct::Inl(hlist!["error"])));
+    assert_eq!(from_generic::<Result<i32, &str>, _>(ok_repr), Ok(42));
+    assert_eq!(from_generic::<Result<i32, &str>, _>(err_repr), Err("error"));
+}
+
+#[test]
+fn test_bool_generic() {
+    type BoolRepr = <bool as Generic>::Repr;
+
+    let false_repr: BoolRepr = into_generic(false);
+    let true_repr: BoolRepr = into_generic(true);
+    let expected_false: BoolRepr = Coproduct::Inl(hlist![]);
+    let expected_true: BoolRepr = Coproduct::Inr(Coproduct::Inl(hlist![]));
+
+    assert_eq!(false_repr, expected_false);
+    assert_eq!(true_repr, expected_true);
+    assert!(!from_generic::<bool, _>(expected_false));
+    assert!(from_generic::<bool, _>(expected_true));
 }
 
 #[test]

--- a/tests/labelled_tests.rs
+++ b/tests/labelled_tests.rs
@@ -241,6 +241,64 @@ fn test_enum_into_labelled_generic() {
 }
 
 #[test]
+fn test_option_labelled_generic() {
+    let none_repr = into_labelled_generic(None::<i32>);
+    let some_repr = into_labelled_generic(Some(42i32));
+
+    assert_eq!(none_repr, Coproduct::Inl(field!((N, o, n, e), hlist![])));
+    assert_eq!(
+        some_repr,
+        Coproduct::Inr(Coproduct::Inl(field!(
+            (S, o, m, e),
+            hlist![field!((__, _0), 42i32, "_0")]
+        )))
+    );
+    assert_eq!(from_labelled_generic::<Option<i32>, _>(none_repr), None);
+    assert_eq!(from_labelled_generic::<Option<i32>, _>(some_repr), Some(42));
+}
+
+#[test]
+fn test_result_labelled_generic() {
+    let ok_repr = into_labelled_generic(Ok::<i32, &str>(42));
+    let err_repr = into_labelled_generic(Err::<i32, &str>("error"));
+
+    assert_eq!(
+        ok_repr,
+        Coproduct::Inl(field!((O, k), hlist![field!((__, _0), 42i32, "_0")]))
+    );
+    assert_eq!(
+        err_repr,
+        Coproduct::Inr(Coproduct::Inl(field!(
+            (E, r, r),
+            hlist![field!((__, _0), "error", "_0")]
+        )))
+    );
+    assert_eq!(
+        from_labelled_generic::<Result<i32, &str>, _>(ok_repr),
+        Ok(42)
+    );
+    assert_eq!(
+        from_labelled_generic::<Result<i32, &str>, _>(err_repr),
+        Err("error")
+    );
+}
+
+#[test]
+fn test_bool_labelled_generic() {
+    type BoolRepr = <bool as LabelledGeneric>::Repr;
+
+    let false_repr: BoolRepr = into_labelled_generic(false);
+    let true_repr: BoolRepr = into_labelled_generic(true);
+    let expected_false: BoolRepr = Coproduct::Inl(field!((f, a, l, s, e), hlist![]));
+    let expected_true: BoolRepr = Coproduct::Inr(Coproduct::Inl(field!((t, r, u, e), hlist![])));
+
+    assert_eq!(false_repr, expected_false);
+    assert_eq!(true_repr, expected_true);
+    assert!(!from_labelled_generic::<bool, _>(expected_false));
+    assert!(from_labelled_generic::<bool, _>(expected_true));
+}
+
+#[test]
 fn test_sculpt_enum() {
     let value = LabelledEnum1::VariantC {
         x: "test".into(),


### PR DESCRIPTION
## Summary

This adds enum support to `#[derive(Generic)]`.

Enum `Generic` representations now mirror the existing `LabelledGeneric` enum shape, but without labels: each variant maps to an `HList` payload, and the enum as a whole maps to a `Coproduct` of those payload `HList`s. Unit variants use `HNil`, tuple variants use positional payloads, and named variants use field-order payloads.

For example, this enum:

```rust
#[derive(Generic)]
enum Event {
    Ping,
    Login(String, bool),
    Logout { user_id: u64 },
}
```

gets a representation equivalent to:

```rust
type Repr = Coprod!(
    HList!(),
    HList!(String, bool),
    HList!(u64)
);
```

with values mapping by variant position:

```rust
Event::Ping
// => Coproduct::Inl(hlist![])

Event::Login(name, admin)
// => Coproduct::Inr(Coproduct::Inl(hlist![name, admin]))

Event::Logout { user_id }
// => Coproduct::Inr(Coproduct::Inr(Coproduct::Inl(hlist![user_id])))
```

So each variant payload becomes an `HList`, and the enum is represented as a `Coproduct` over those payload lists.

This also adds manual `Generic` and `LabelledGeneric` impls for:

- `Option<T>`
- `Result<T, E>`
- `bool`

The std enum impls use the same representation conventions as derived enums. For `LabelledGeneric`, variant labels are `None`, `Some`, `Ok`, `Err`, `false`, and `true`, with unary tuple payloads using the existing `_0` field label convention.

## Changes

- Adds plain enum support to `#[derive(Generic)]`.
- Reuses proc macro helper machinery for enum variant payload `HList`s.
- Adds `Generic` impls for `Option`, `Result`, and `bool`.
- Adds `LabelledGeneric` impls for `Option`, `Result`, and `bool`.
- Adds tests for enum derive round trips and exact representation shapes.

## Testing

Ran:

```bash
cargo test --test generic_tests
cargo test --test labelled_tests
cargo test --workspace
cargo check -p frunk_core --no-default-features
```